### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.2.0 - 2026-07-01
 
 ### Added
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AdditionalDistributions"
 uuid = "6655a985-646a-4595-ab89-59c8a6085518"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["Santiago Jimenez Ramos <santymax9807@gmail.com>"]
 description = "Additional probability distributions for Julia, implementing the core Distributions.jl interface."
 


### PR DESCRIPTION
This PR prepares the v0.2.0 release.

Changes:

- Bumps the package version to `0.2.0`.
- Updates the changelog for the v0.2.0 release.