### PR TITLE
Refactor/multivariate api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Direct `cdf_result` support for native `Distributions.AbstractMvNormal` and
+  `Distributions.AbstractMvTDist` objects.
+- One-sided multivariate CDF convenience methods `cdf(d, x)` for
+  `MvGaussian` and `MvTStudent`.
+- API-level regression tests covering native/wrapper agreement.
+
+### Changed
+
+- `MvGaussian` now participates directly in the
+  `Distributions.AbstractMvNormal` interface and delegates only the primitive
+  operations required by that abstraction.
+- `MvTStudent` is now explicitly typed around
+  `Distributions.AbstractMvTDist`, while preserving the distinction between
+  Student-t location/scale parameters and statistical mean/covariance.
+- Multivariate documentation now describes native `Distributions.jl`
+  interoperability and the type-piracy boundary.
+
 ## 0.2.0 - 2026-07-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ Pkg.add(url="https://github.com/Santymax98/AdditionalDistributions.jl")
 - Additional continuous and discrete univariate distributions.
 - Zero-inflated discrete models such as `ZIP`, `ZIB`, and `ZINB`.
 - Heavy-tailed distributions such as `Burr`, `Lomax`, and `Zeta`.
-- Rectangular CDF evaluation for `MvGaussian`.
-- Rectangular CDF evaluation for `MvTStudent`.
+- `MvGaussian` integrated with the `Distributions.AbstractMvNormal` interface.
+- Rectangular CDF evaluation for `MvGaussian` and `MvTStudent`.
+- Direct `cdf_result` support for native `Distributions.MvNormal` and `Distributions.MvTDist` objects.
 - Structured multivariate CDF diagnostics through `CDFResult` and `cdf_result`.
 - Reproducible randomized QMC integration when a seeded RNG is provided.
 - Reference tests and benchmark scripts for multivariate CDF evaluation.
@@ -131,6 +132,33 @@ res_t = cdf_result(mvt, lower, upper;
 
 The multivariate Student-t implementation uses the normal-scale-mixture representation. Even with a diagonal scale matrix, its components are not treated as independent univariate Student-t random variables, because they share a common radial scale.
 
+### Native `Distributions.jl` interoperability
+
+The rectangular-probability backend can also be used directly with native
+`Distributions.jl` objects:
+
+```julia
+using Distributions
+
+dn = MvNormal(zeros(d), Σ)
+rn = cdf_result(dn, lower, upper; rng=MersenneTwister(1234))
+
+dt = MvTDist(ν, zeros(d), Σ)
+rt = cdf_result(dt, lower, upper; rng=MersenneTwister(1234))
+```
+
+`cdf_result` is owned by `AdditionalDistributions.jl`, so this interoperability
+does not require extending `Distributions.cdf` on external distribution types.
+For the wrapper types, the natural scalar-valued interface remains available:
+
+```julia
+cdf(MvGaussian(zeros(d), Σ), upper)
+cdf(MvGaussian(zeros(d), Σ), lower, upper)
+
+cdf(MvTStudent(ν, zeros(d), Σ), upper)
+cdf(MvTStudent(ν, zeros(d), Σ), lower, upper)
+```
+
 ---
 
 ## Multivariate CDF controls
@@ -142,7 +170,7 @@ The multivariate Student-t implementation uses the normal-scale-mixture represen
 | `releps` | Relative error tolerance. |
 | `rng` | Random number generator used for randomized shifts. Fix it for reproducibility. |
 | `nshifts` | Number of randomized QMC shifts. Defaults: `12` for `MvGaussian`, `16` for `MvTStudent`. |
-| `batchsize` | Internal batch size. `nothing` or an automatic setting lets the implementation choose a value. |
+| `batchsize` | Internal batch size. Use `0` (the default) to let the implementation choose automatically. |
 | `pivot` | Whether to use the MVSORT variable reordering step. |
 | `antithetic` | Optional antithetic reflection when available. |
 

--- a/docs/src/bestiary/multivariate.md
+++ b/docs/src/bestiary/multivariate.md
@@ -10,8 +10,11 @@ P(a_i \le X_i \le b_i,\quad i = 1,\ldots,d).
 
 The package currently focuses on:
 
-- `MvGaussian`, based on `Distributions.MvNormal`;
-- `MvTStudent`, based on `Distributions.MvTDist`.
+- `MvGaussian`, which participates directly in the
+  `Distributions.AbstractMvNormal` interface;
+- `MvTStudent`, a typed wrapper around `Distributions.AbstractMvTDist`;
+- `cdf_result` support for both the package wrappers and native
+  `Distributions.MvNormal` / `Distributions.MvTDist` objects.
 
 ```@docs
 MvGaussian
@@ -67,6 +70,44 @@ res = cdf_result(mvt, lower, upper;
 
 The Student-t CDF is usually harder than the Gaussian CDF because it uses the normal-scale-mixture representation and an additional chi-square coordinate. Small degrees of freedom, high dimension, strong dependence, and tail rectangles may require larger `m`.
 
+## Native `Distributions.jl` interoperability
+
+The same rectangular-probability backend is available directly for native
+`Distributions.jl` multivariate distributions:
+
+```julia
+using Distributions
+
+dn = MvNormal(zeros(d), Σ)
+rn = cdf_result(dn, lower, upper;
+    m = 100_000,
+    rng = MersenneTwister(1234),
+)
+
+dt = MvTDist(ν, zeros(d), Σ)
+rt = cdf_result(dt, lower, upper;
+    m = 1_000_000,
+    nshifts = 16,
+    rng = MersenneTwister(1234),
+)
+```
+
+This is intentionally provided through `cdf_result`, a function owned by
+`AdditionalDistributions.jl`. The package does **not** add
+`Distributions.cdf(::MvNormal, ...)` or `Distributions.cdf(::MvTDist, ...)`
+methods, avoiding type piracy.
+
+For package-owned wrapper types, both one-sided and rectangular scalar CDFs are
+available:
+
+```julia
+cdf(mvnormal, upper)         # P(Xᵢ ≤ upperᵢ for all i)
+cdf(mvnormal, lower, upper)  # P(lowerᵢ ≤ Xᵢ ≤ upperᵢ for all i)
+
+cdf(mvt, upper)
+cdf(mvt, lower, upper)
+```
+
 ## API summary
 
 ```julia
@@ -79,7 +120,8 @@ returns only the probability estimate.
 cdf_result(dist, lower, upper; kwargs...)
 ```
 
-returns a structured result:
+accepts `MvGaussian`, `MvTStudent`, native `MvNormal`, and native `MvTDist`
+objects and returns a structured result:
 
 ```julia
 res.value

--- a/src/multivariate/MvGaussian.jl
+++ b/src/multivariate/MvGaussian.jl
@@ -1,123 +1,241 @@
 """
     MvGaussian(μ::AbstractVector, Σ::AbstractMatrix)
 
-A *Multivariate Gaussian (Normal) distribution* equivalent in behavior to
-[`Distributions.MvNormal`](https://juliastats.org/Distributions.jl/stable/multivariate/#Distributions.MvNormal),
-but using a **custom folded batch randomized quasi-Monte Carlo integrator** for the cumulative
-distribution function (`cdf`).
+A multivariate Gaussian distribution backed by `Distributions.AbstractMvNormal`,
+with rectangular cumulative probabilities evaluated by the custom
+Genz/Richtmyer randomized quasi-Monte Carlo backend in
+`AdditionalDistributions.jl`.
 
-This type preserves all the standard functionality of `MvNormal` — including
-`pdf`, `logpdf`, `rand`, `mean`, and `cov` — while providing its own
-implementation of `cdf(a, b)` for rectangular probabilities under a
-multivariate normal law.
+`MvGaussian` participates in the `Distributions.jl` `AbstractMvNormal`
+interface, so standard functionality such as `pdf`, `logpdf`, `rand`,
+`insupport`, `mode`, and `entropy` is inherited from `Distributions.jl`
+through a small set of delegated primitives.
 
 ```julia
 MvGaussian(Σ)        # zero-mean version
 MvGaussian(μ, Σ)     # with explicit mean and covariance
-params(d)            # returns (μ, Σ)
-cdf(d, a, b)         # evaluates P(a ≤ X ≤ b)
+
+params(d)            # (μ, Σ)
+cdf(d, x)            # P(X₁ ≤ x₁, ..., Xₚ ≤ xₚ)
+cdf(d, a, b)         # P(a ≤ X ≤ b)
+cdf_result(d, a, b)  # structured numerical result
 ```
-
-External link:
-
-* [Multivariate normal distribution - Wikipedia](https://en.wikipedia.org/wiki/Multivariate_normal_distribution)
 """
-struct MvGaussian{D<:Distributions.MvNormal} <: Distributions.ContinuousMultivariateDistribution
+struct MvGaussian{D<:Distributions.AbstractMvNormal} <: Distributions.AbstractMvNormal
     dist::D
 end
 
-MvGaussian(μ::AbstractVector, Σ::AbstractMatrix) = MvGaussian(Distributions.MvNormal(μ, Σ))
-MvGaussian(Σ::AbstractMatrix) = MvGaussian(Distributions.MvNormal(zeros(size(Σ, 1)), Σ))
+MvGaussian(μ::AbstractVector, Σ::AbstractMatrix) =
+    MvGaussian(Distributions.MvNormal(μ, Σ))
+
+MvGaussian(Σ::AbstractMatrix) =
+    MvGaussian(Distributions.MvNormal(Σ))
 
 
-# Delegaciones
-Statistics.mean(d::MvGaussian) = Statistics.mean(d.dist)
-Statistics.cov(d::MvGaussian)  = Statistics.cov(d.dist)
-Distributions.pdf(d::MvGaussian, x::AbstractVector)    = Distributions.pdf(d.dist, x)
-Distributions.logpdf(d::MvGaussian, x::AbstractVector) = Distributions.logpdf(d.dist, x)
-Distributions.rand(rng::Distributions.AbstractRNG, d::MvGaussian) = Distributions.rand(rng, d.dist)
-Distributions.rand(rng::Distributions.AbstractRNG, d::MvGaussian, n::Int) = Distributions.rand(rng, d.dist, n)
-Distributions.insupport(d::MvGaussian, x::AbstractVector)         = Distributions.insupport(d.dist, x)
-params(d::MvGaussian) = (Statistics.mean(d), Statistics.cov(d))
+# ------------------------------------------------------------------
+# AbstractMvNormal primitives
+# ------------------------------------------------------------------
+
 Base.length(d::MvGaussian) = length(d.dist)
 
+Base.eltype(::Type{MvGaussian{D}}) where {D<:Distributions.AbstractMvNormal} =
+    eltype(D)
+
+Statistics.mean(d::MvGaussian) = Statistics.mean(d.dist)
+Statistics.var(d::MvGaussian) = Statistics.var(d.dist)
+Statistics.cov(d::MvGaussian) = Statistics.cov(d.dist)
+
+params(d::MvGaussian) = params(d.dist)
+partype(d::MvGaussian) = partype(d.dist)
+
+Distributions.invcov(d::MvGaussian) =
+    Distributions.invcov(d.dist)
+
+Distributions.logdetcov(d::MvGaussian) =
+    Distributions.logdetcov(d.dist)
+
+Distributions.sqmahal(d::MvGaussian, x::AbstractVector) =
+    Distributions.sqmahal(d.dist, x)
+
+Distributions.sqmahal!(r::AbstractVector, d::MvGaussian, x::AbstractMatrix) =
+    Distributions.sqmahal!(r, d.dist, x)
+
+Distributions.gradlogpdf(d::MvGaussian, x::AbstractVector{<:Real}) =
+    Distributions.gradlogpdf(d.dist, x)
+
+Distributions._rand!(
+    rng::Distributions.AbstractRNG,
+    d::MvGaussian,
+    x::AbstractVector,
+) = Distributions._rand!(rng, d.dist, x)
+
+Distributions._rand!(
+    rng::Distributions.AbstractRNG,
+    d::MvGaussian,
+    x::AbstractMatrix,
+) = Distributions._rand!(rng, d.dist, x)
+
+
+# ------------------------------------------------------------------
+# Rectangular Gaussian probabilities
+# ------------------------------------------------------------------
 
 """
-    cdf_result(d::MvGaussian, a, b; m=1000*length(a), abseps=1e-6,
-               releps=1e-6, pivot=true, rng=Random.default_rng(),
+    cdf_result(d::Distributions.AbstractMvNormal, a, b;
+               m=1000*length(a), abseps=1e-6, releps=1e-6,
+               pivot=true, rng=Random.default_rng(),
                antithetic=false, batchsize=0, nshifts=12)
 
-Estimate the rectangular probability `P(a ≤ X ≤ b)` for a multivariate
-Gaussian distribution and return a [`CDFResult`](@ref).
+Estimate the rectangular probability `P(a ≤ X ≤ b)` for any
+`Distributions.AbstractMvNormal` and return a [`CDFResult`](@ref).
 
-The Gaussian path uses MVSORT reordering, a Genz-style conditional
-transformation, folded randomized Richtmyer QMC points, and batch evaluation.
-If the covariance matrix is diagonal, the probability is evaluated exactly by
-factorization.
-
-Use `cdf(d, a, b)` for the scalar probability, or `cdf(d, a, b; full=true)` for
-the legacy `(value, error, inform)` tuple.
+This method is owned by `AdditionalDistributions.jl`, so it can legally extend
+the CDF functionality of native `Distributions.MvNormal` objects without
+extending `Distributions.cdf(::MvNormal, ...)`.
 """
-function cdf_result(d::MvGaussian,
-                    a::AbstractVector, b::AbstractVector;
-                    m::Int=1000*length(a),
-                    abseps::Real=1e-6,
-                    releps::Real=1e-6,
-                    pivot::Bool=true,
-                    rng=Random.default_rng(),
-                    antithetic::Bool=false,
-                    batchsize::Int=0,
-                    nshifts::Int=12)
+function cdf_result(
+    d::Distributions.AbstractMvNormal,
+    a::AbstractVector,
+    b::AbstractVector;
+    m::Int=1000 * length(a),
+    abseps::Real=1e-6,
+    releps::Real=1e-6,
+    pivot::Bool=true,
+    rng=Random.default_rng(),
+    antithetic::Bool=false,
+    batchsize::Int=0,
+    nshifts::Int=12,
+)
+    n = length(d)
 
-    n = length(a)
-    length(b) == n || throw(DimensionMismatch("length(a) ≠ length(b)"))
+    length(a) == n ||
+        throw(DimensionMismatch("length(a) ≠ length(d)"))
+    length(b) == n ||
+        throw(DimensionMismatch("length(b) ≠ length(d)"))
 
     μ = Statistics.mean(d)
     Σ = Statistics.cov(d)
 
-    size(Σ) == (n, n) || throw(DimensionMismatch("Σ must be n×n"))
+    size(Σ) == (n, n) ||
+        throw(DimensionMismatch("Σ must be n×n"))
 
-    T = promote_type(Float64, eltype(a), eltype(b), eltype(μ), eltype(Σ))
+    T = promote_type(
+        Float64,
+        eltype(a),
+        eltype(b),
+        eltype(μ),
+        eltype(Σ),
+    )
 
-    if any(b .< a)
-        return CDFResult(zero(T), zero(T), 0, 0, :empty_rectangle)
+    @inbounds for i in 1:n
+        if b[i] < a[i]
+            return CDFResult(
+                zero(T),
+                zero(T),
+                0,
+                0,
+                :empty_rectangle,
+            )
+        end
     end
 
     if n == 1
-        μ1 = μ[1]
-        σ1 = sqrt(Σ[1, 1])
-        val = Distributions.cdf(Distributions.Normal(μ1, σ1), b[1]) -
-              Distributions.cdf(Distributions.Normal(μ1, σ1), a[1])
-        val = clamp(T(val), zero(T), one(T))
-        return CDFResult(val, zero(T), 0, 0, :univariate_exact)
+        μ1 = T(μ[1])
+        σ1 = sqrt(T(Σ[1, 1]))
+
+        val =
+            Distributions.cdf(
+                Distributions.Normal(μ1, σ1),
+                T(b[1]),
+            ) -
+            Distributions.cdf(
+                Distributions.Normal(μ1, σ1),
+                T(a[1]),
+            )
+
+        return CDFResult(
+            clamp(T(val), zero(T), one(T)),
+            zero(T),
+            0,
+            0,
+            :univariate_exact,
+        )
     end
 
-    Σb = T.(Σ)
+    Σb = Matrix{T}(Σ)
     ab = T.(a)
     bb = T.(b)
     δb = T.(μ)
 
-    res = mvtcdf(Σb, ab, bb;
-                 ν=0,
-                 δ=δb,
-                 maxpts=m,
-                 abseps=abseps,
-                 releps=releps,
-                 assume_correlation=false,
-                 pivot=pivot,
-                 antithetic=antithetic,
-                 rng=rng,
-                 batchsize=batchsize,
-                 nshifts=nshifts)
+    res = mvtcdf(
+        Σb,
+        ab,
+        bb;
+        ν=0,
+        δ=δb,
+        maxpts=m,
+        abseps=abseps,
+        releps=releps,
+        assume_correlation=false,
+        pivot=pivot,
+        antithetic=antithetic,
+        rng=rng,
+        batchsize=batchsize,
+        nshifts=nshifts,
+    )
 
-    return CDFResult(T(res.value), T(res.error), res.inform, m, :mvsort_rqmc)
+    return CDFResult(
+        T(res.value),
+        T(res.error),
+        res.inform,
+        m,
+        :mvsort_rqmc,
+    )
 end
 
-function Distributions.cdf(d::MvGaussian,
-                           a::AbstractVector, b::AbstractVector;
-                           full::Bool=false,
-                           kwargs...)
 
+# Private scalar-value convenience API owned by AdditionalDistributions.
+_cdf(
+    d::Distributions.AbstractMvNormal,
+    a::AbstractVector,
+    b::AbstractVector;
+    kwargs...,
+) = cdf_result(d, a, b; kwargs...).value
+
+function _cdf(
+    d::Distributions.AbstractMvNormal,
+    x::AbstractVector;
+    kwargs...,
+)
+    length(x) == length(d) ||
+        throw(DimensionMismatch("length(x) ≠ length(d)"))
+
+    a = fill(-Inf, length(d))
+    return _cdf(d, a, x; kwargs...)
+end
+
+
+# Public Distributions.cdf methods are defined only for our type.
+function Distributions.cdf(
+    d::MvGaussian,
+    a::AbstractVector,
+    b::AbstractVector;
+    full::Bool=false,
+    kwargs...,
+)
     res = cdf_result(d, a, b; kwargs...)
     return full ? (res.value, res.error, res.inform) : res.value
+end
+
+function Distributions.cdf(
+    d::MvGaussian,
+    x::AbstractVector;
+    full::Bool=false,
+    kwargs...,
+)
+    length(x) == length(d) ||
+        throw(DimensionMismatch("length(x) ≠ length(d)"))
+
+    a = fill(-Inf, length(d))
+    return Distributions.cdf(d, a, x; full=full, kwargs...)
 end

--- a/src/multivariate/MvStudent.jl
+++ b/src/multivariate/MvStudent.jl
@@ -1,110 +1,202 @@
 """
     MvTStudent(ν::Real, μ::AbstractVector, Σ::AbstractMatrix)
 
-A *Multivariate Student's t distribution* equivalent in behavior to
-[`Distributions.MvTDist`](https://juliastats.org/Distributions.jl/stable/multivariate/#Distributions.MvTDist),
-but using a custom pure-Julia Genz-Bretz/Richtmyer randomized QMC integrator
-for rectangular cumulative distribution functions.
+A multivariate Student's t distribution backed by a native
+`Distributions.AbstractMvTDist`, with rectangular cumulative probabilities
+evaluated by the custom Genz-Bretz/Richtmyer randomized QMC backend in
+`AdditionalDistributions.jl`.
 
-This type preserves the standard functionality of `MvTDist` — including
-`pdf`, `logpdf`, `rand`, `mean`, and `cov` — while providing its own
-implementation of `cdf(a, b)` for rectangular probabilities under a
-multivariate t law.
+`Σ` is the scale/scatter matrix used by `Distributions.MvTDist`; it is not
+generally the covariance matrix.
 
 ```julia
-MvTStudent(ν, Σ)             # zero-location version with df=ν
-MvTStudent(ν, μ, Σ)          # with degrees of freedom ν, location μ, and scale Σ
+MvTStudent(ν, Σ)
+MvTStudent(ν, μ, Σ)
 
-params(d)                    # returns (ν, μ, Σ)
-cdf(d, a, b)                 # evaluates P(a ≤ X ≤ b)
-cdf_result(d, a, b)          # returns value, error, inform and algorithm metadata
+params(d)            # (ν, μ, Σ)
+cdf(d, x)            # P(X₁ ≤ x₁, ..., Xₚ ≤ xₚ)
+cdf(d, a, b)         # P(a ≤ X ≤ b)
+cdf_result(d, a, b)  # structured numerical result
 ```
 """
-struct MvTStudent{D} <: ContinuousMultivariateDistribution
+struct MvTStudent{D<:Distributions.AbstractMvTDist} <:
+       Distributions.ContinuousMultivariateDistribution
     dist::D
 end
 
-MvTStudent(ν::Real, μ::AbstractVector, Σ::AbstractMatrix) = MvTStudent(Distributions.MvTDist(ν, μ, Σ))
-MvTStudent(ν::Real, Σ::AbstractMatrix) = MvTStudent(Distributions.MvTDist(ν, zeros(size(Σ, 1)), Σ))
+MvTStudent(
+    ν::Real,
+    μ::AbstractVector,
+    Σ::AbstractMatrix,
+) = MvTStudent(Distributions.MvTDist(ν, collect(μ), Matrix(Σ)))
 
-# ──────────────────────────
-# Standard method delegation
-# ──────────────────────────
-Statistics.mean(d::MvTStudent) = Statistics.mean(d.dist)
-Statistics.cov(d::MvTStudent) = Statistics.cov(d.dist)
-Distributions.pdf(d::MvTStudent, x::AbstractVector) = Distributions.pdf(d.dist, x)
-Distributions.logpdf(d::MvTStudent, x::AbstractVector) = Distributions.logpdf(d.dist, x)
-Distributions.rand(rng::Distributions.AbstractRNG, d::MvTStudent) = Distributions.rand(rng, d.dist)
-Distributions.rand(rng::Distributions.AbstractRNG, d::MvTStudent, n::Int) = Distributions.rand(rng, d.dist, n)
-Distributions.insupport(d::MvTStudent, x::AbstractVector) = Distributions.insupport(d.dist, x)
-params(d::MvTStudent) = (d.dist.df, d.dist.μ, d.dist.Σ)
+MvTStudent(
+    ν::Real,
+    Σ::AbstractMatrix,
+) = MvTStudent(
+    Distributions.MvTDist(
+        ν,
+        zeros(eltype(Σ), size(Σ, 1)),
+        Matrix(Σ),
+    ),
+)
+
+
+# ------------------------------------------------------------------
+# Standard wrapper delegation
+# ------------------------------------------------------------------
+
 Base.length(d::MvTStudent) = length(d.dist)
 
-# ───────────────────────────────
-# Rectangular CDF by Genz-Bretz/Richtmyer RQMC
-# ───────────────────────────────
+Base.eltype(::Type{MvTStudent{D}}) where {D<:Distributions.AbstractMvTDist} =
+    eltype(D)
+
+Statistics.mean(d::MvTStudent) = Statistics.mean(d.dist)
+Statistics.var(d::MvTStudent) = Statistics.var(d.dist)
+Statistics.cov(d::MvTStudent) = Statistics.cov(d.dist)
+
+Distributions.pdf(d::MvTStudent, x::AbstractVector) =
+    Distributions.pdf(d.dist, x)
+
+Distributions.logpdf(d::MvTStudent, x::AbstractVector) =
+    Distributions.logpdf(d.dist, x)
+
+Distributions.rand(
+    rng::Distributions.AbstractRNG,
+    d::MvTStudent,
+) = Distributions.rand(rng, d.dist)
+
+Distributions.rand(
+    rng::Distributions.AbstractRNG,
+    d::MvTStudent,
+    n::Int,
+) = Distributions.rand(rng, d.dist, n)
+
+Distributions.insupport(d::MvTStudent, x::AbstractVector) =
+    Distributions.insupport(d.dist, x)
+
+Distributions.scale(d::MvTStudent) =
+    Distributions.scale(d.dist)
+
+Distributions.invcov(d::MvTStudent) =
+    Distributions.invcov(d.dist)
+
+StatsBase.mode(d::MvTStudent) =
+    StatsBase.mode(d.dist)
+
+StatsBase.entropy(d::MvTStudent) =
+    StatsBase.entropy(d.dist)
+
+params(d::MvTStudent) = params(d.dist)
+partype(d::MvTStudent) = partype(d.dist)
+
+
+# ------------------------------------------------------------------
+# Rectangular Student-t probabilities
+# ------------------------------------------------------------------
+
 """
-    cdf_result(d::MvTStudent, a, b; m=max(100_000, 10_000*length(a)),
+    cdf_result(d::Distributions.AbstractMvTDist, a, b;
+               m=max(100_000, 10_000*length(a)),
                abseps=1e-6, releps=1e-6, pivot=true,
                rng=Random.default_rng(), antithetic=false,
                batchsize=0, nshifts=16)
 
-Estimate the rectangular probability `P(a ≤ X ≤ b)` for a multivariate
-Student's t distribution and return a [`CDFResult`](@ref).
+Estimate `P(a ≤ X ≤ b)` for a native `Distributions.AbstractMvTDist` and
+return a [`CDFResult`](@ref).
 
-The Student's t path uses the scale-mixture representation of the t law with
-an additional chi-square coordinate, combined with the same conditional
-Gaussian transformation used by `MvGaussian`. The Gaussian coordinates are
-folded; the chi-square coordinate is not folded.
-
-Small degrees of freedom, high dimensions, strong correlations, or tail
-rectangles may require a larger `m`.
+The calculation uses the t distribution's location `μ` and scale/scatter
+matrix `Σ`, not its statistical mean and covariance.
 """
-function cdf_result(d::MvTStudent,
-                    a::AbstractVector, b::AbstractVector;
-                    m::Int=max(100_000, 10_000 * length(a)),
-                    abseps::Real=1e-6,
-                    releps::Real=1e-6,
-                    pivot::Bool=true,
-                    rng=Random.default_rng(),
-                    antithetic::Bool=false,
-                    batchsize::Int=0,
-                    nshifts::Int=16)
+function cdf_result(
+    d::Distributions.AbstractMvTDist,
+    a::AbstractVector,
+    b::AbstractVector;
+    m::Int=max(100_000, 10_000 * length(a)),
+    abseps::Real=1e-6,
+    releps::Real=1e-6,
+    pivot::Bool=true,
+    rng=Random.default_rng(),
+    antithetic::Bool=false,
+    batchsize::Int=0,
+    nshifts::Int=16,
+)
+    n = length(d)
 
-    n = length(a)
-    length(b) == n || throw(DimensionMismatch("length(a) ≠ length(b)"))
+    length(a) == n ||
+        throw(DimensionMismatch("length(a) ≠ length(d)"))
+    length(b) == n ||
+        throw(DimensionMismatch("length(b) ≠ length(d)"))
 
-    μ = d.dist.μ
-    Σscale = d.dist.Σ
-    ν = d.dist.df
+    # Distributions.jl's AbstractMvTDist interface itself relies on these
+    # canonical fields. Importantly, μ is location and Σ is scale/scatter.
+    μ = d.μ
+    Σscale = d.Σ
+    ν = d.df
 
-    size(Σscale) == (n, n) || throw(DimensionMismatch("Σ must be n×n"))
+    size(Σscale) == (n, n) ||
+        throw(DimensionMismatch("Σ must be n×n"))
 
-    T = promote_type(Float64, eltype(a), eltype(b), eltype(μ), eltype(Σscale))
+    T = promote_type(
+        Float64,
+        eltype(a),
+        eltype(b),
+        eltype(μ),
+        eltype(Σscale),
+        typeof(ν),
+    )
 
     @inbounds for i in 1:n
         if b[i] < a[i]
-            return CDFResult(zero(T), zero(T), 0, 0, :empty_rectangle)
+            return CDFResult(
+                zero(T),
+                zero(T),
+                0,
+                0,
+                :empty_rectangle,
+            )
         end
     end
 
-    # Standardize to zero-location, unit diagonal scale. For the multivariate t,
-    # Σscale is the scatter/scale matrix used by MvTDist, not necessarily the
-    # covariance matrix. This diagonal scaling preserves the t dependence and
-    # passes a correlation-like scale matrix to the core integrator.
+    if n == 1
+        μ1 = T(μ[1])
+        σ1 = sqrt(T(Σscale[1, 1]))
+        td = Distributions.TDist(T(ν))
+
+        za = (T(a[1]) - μ1) / σ1
+        zb = (T(b[1]) - μ1) / σ1
+
+        val = Distributions.cdf(td, zb) - Distributions.cdf(td, za)
+
+        return CDFResult(
+            clamp(T(val), zero(T), one(T)),
+            zero(T),
+            0,
+            0,
+            :univariate_exact_t,
+        )
+    end
+
     Ddiag = Vector{T}(undef, n)
     invD = Vector{T}(undef, n)
+
     @inbounds for i in 1:n
         Ddiag[i] = sqrt(T(Σscale[i, i]))
         invD[i] = inv(Ddiag[i])
     end
 
     C = Matrix{T}(undef, n, n)
+
     @inbounds begin
         for j in 1:n
             C[j, j] = one(T)
-            for i in j+1:n
-                cij = T(Σscale[i, j]) * invD[i] * invD[j]
+
+            for i in (j + 1):n
+                cij =
+                    T(Σscale[i, j]) *
+                    invD[i] *
+                    invD[j]
+
                 C[i, j] = cij
                 C[j, i] = cij
             end
@@ -114,32 +206,89 @@ function cdf_result(d::MvTStudent,
     aS = Vector{T}(undef, n)
     bS = Vector{T}(undef, n)
     δS = zeros(T, n)
+
     @inbounds for i in 1:n
         aS[i] = (T(a[i]) - T(μ[i])) * invD[i]
         bS[i] = (T(b[i]) - T(μ[i])) * invD[i]
     end
 
-    res = mvtcdf(C, aS, bS;
-                 ν=ν,
-                 δ=δS,
-                 maxpts=m,
-                 abseps=abseps,
-                 releps=releps,
-                 assume_correlation=true,
-                 pivot=pivot,
-                 antithetic=antithetic,
-                 rng=rng,
-                 batchsize=batchsize,
-                 nshifts=nshifts)
+    res = mvtcdf(
+        C,
+        aS,
+        bS;
+        ν=T(ν),
+        δ=δS,
+        maxpts=m,
+        abseps=abseps,
+        releps=releps,
+        assume_correlation=true,
+        pivot=pivot,
+        antithetic=antithetic,
+        rng=rng,
+        batchsize=batchsize,
+        nshifts=nshifts,
+    )
 
-    return CDFResult(T(res.value), T(res.error), res.inform, m, :mvsort_rqmc_t)
+    return CDFResult(
+        T(res.value),
+        T(res.error),
+        res.inform,
+        m,
+        :mvsort_rqmc_t,
+    )
 end
 
-function Distributions.cdf(d::MvTStudent,
-                           a::AbstractVector, b::AbstractVector;
-                           full::Bool=false,
-                           kwargs...)
 
+cdf_result(
+    d::MvTStudent,
+    a::AbstractVector,
+    b::AbstractVector;
+    kwargs...,
+) = cdf_result(d.dist, a, b; kwargs...)
+
+
+# Private scalar-value convenience API owned by AdditionalDistributions.
+_cdf(
+    d::Distributions.AbstractMvTDist,
+    a::AbstractVector,
+    b::AbstractVector;
+    kwargs...,
+) = cdf_result(d, a, b; kwargs...).value
+
+function _cdf(
+    d::Distributions.AbstractMvTDist,
+    x::AbstractVector;
+    kwargs...,
+)
+    length(x) == length(d) ||
+        throw(DimensionMismatch("length(x) ≠ length(d)"))
+
+    a = fill(-Inf, length(d))
+    return _cdf(d, a, x; kwargs...)
+end
+
+
+# Public Distributions.cdf methods are defined only for our wrapper type.
+function Distributions.cdf(
+    d::MvTStudent,
+    a::AbstractVector,
+    b::AbstractVector;
+    full::Bool=false,
+    kwargs...,
+)
     res = cdf_result(d, a, b; kwargs...)
     return full ? (res.value, res.error, res.inform) : res.value
+end
+
+function Distributions.cdf(
+    d::MvTStudent,
+    x::AbstractVector;
+    full::Bool=false,
+    kwargs...,
+)
+    length(x) == length(d) ||
+        throw(DimensionMismatch("length(x) ≠ length(d)"))
+
+    a = fill(-Inf, length(d))
+    return Distributions.cdf(d, a, x; full=full, kwargs...)
 end

--- a/test/multivariate_api_test.jl
+++ b/test/multivariate_api_test.jl
@@ -1,0 +1,80 @@
+using TestItems
+
+@testitem "MvGaussian – AbstractMvNormal interface" tags=[:multivariate, :api] begin
+    using Test
+    using AdditionalDistributions
+    using Distributions
+    using Statistics
+    using Random
+    using LinearAlgebra
+
+    μ = [0.0, 1.0]
+    Σ = [1.0 0.4;
+         0.4 2.0]
+
+    d  = MvGaussian(μ, Σ)
+    dn = MvNormal(μ, Σ)
+
+    x = [0.3, -0.2]
+
+    @test d isa Distributions.AbstractMvNormal
+
+    @test length(d) == length(dn)
+    @test mean(d) == mean(dn)
+    @test var(d) ≈ var(dn)
+    @test Matrix(cov(d)) ≈ Matrix(cov(dn))
+
+    @test Matrix(invcov(d)) ≈ Matrix(invcov(dn))
+    @test logdetcov(d) ≈ logdetcov(dn)
+    @test sqmahal(d, x) ≈ sqmahal(dn, x)
+    @test gradlogpdf(d, x) ≈ gradlogpdf(dn, x)
+
+    @test pdf(d, x) ≈ pdf(dn, x)
+    @test logpdf(d, x) ≈ logpdf(dn, x)
+    @test entropy(d) ≈ entropy(dn)
+
+    rng1 = MersenneTwister(2024)
+    rng2 = MersenneTwister(2024)
+    @test rand(rng1, d) ≈ rand(rng2, dn)
+
+    @test insupport(d, x) == insupport(dn, x)
+end
+
+
+@testitem "MvGaussian – native CDF backend" tags=[:multivariate, :api, :cdf] begin
+    using Test
+    using AdditionalDistributions
+    using Distributions
+
+    μ = [0.0, 1.0]
+    Σ = [1.0 0.0;
+         0.0 4.0]
+
+    d  = MvGaussian(μ, Σ)
+    dn = MvNormal(μ, Σ)
+
+    a = [-Inf, -Inf]
+    b = [0.0, 1.0]
+
+    expected = 0.25
+
+    rn = cdf_result(dn, a, b)
+    rw = cdf_result(d, a, b)
+
+    @test rn.value ≈ expected atol=1e-14
+    @test rw.value ≈ expected atol=1e-14
+    @test rn.value ≈ rw.value
+
+    @test AdditionalDistributions._cdf(dn, a, b) ≈ expected atol=1e-14
+    @test AdditionalDistributions._cdf(dn, b) ≈ expected atol=1e-14
+
+    @test cdf(d, a, b) ≈ expected atol=1e-14
+    @test cdf(d, b) ≈ expected atol=1e-14
+
+    # Native MvNormal receives CDF functionality only through functions
+    # owned by AdditionalDistributions; Distributions.cdf is not pirated.
+    @test cdf_result(dn, a, b).value == AdditionalDistributions._cdf(dn, a, b)
+
+    @test_throws DimensionMismatch cdf(d, [0.0])
+    @test_throws DimensionMismatch cdf_result(dn, [-Inf], b)
+end

--- a/test/multivariate_student_api_test.jl
+++ b/test/multivariate_student_api_test.jl
@@ -1,0 +1,101 @@
+using TestItems
+
+@testitem "MvTStudent – native wrapper interface" tags=[:multivariate, :api, :student] begin
+    using Test
+    using AdditionalDistributions
+    using Distributions
+    using Statistics
+    using Random
+
+    ν = 5.0
+    μ = [0.5, -1.0]
+    Σ = [1.0 0.25;
+         0.25 2.0]
+
+    d  = MvTStudent(ν, μ, Σ)
+    dn = MvTDist(ν, μ, Σ)
+
+    x = [0.2, -0.3]
+
+    @test d.dist isa Distributions.AbstractMvTDist
+    @test length(d) == length(dn)
+
+    pd = params(d)
+    pn = params(dn)
+    @test pd[1] == pn[1]
+    @test pd[2] ≈ pn[2]
+    @test Matrix(pd[3]) ≈ Matrix(pn[3])
+
+    @test mean(d) ≈ mean(dn)
+    @test var(d) ≈ var(dn)
+    @test cov(d) ≈ cov(dn)
+    @test scale(d) ≈ scale(dn)
+
+    @test pdf(d, x) ≈ pdf(dn, x)
+    @test logpdf(d, x) ≈ logpdf(dn, x)
+    @test entropy(d) ≈ entropy(dn)
+    @test insupport(d, x) == insupport(dn, x)
+
+    rng1 = MersenneTwister(2024)
+    rng2 = MersenneTwister(2024)
+    @test rand(rng1, d) ≈ rand(rng2, dn)
+end
+
+
+@testitem "MvTStudent – native CDF backend" tags=[:multivariate, :api, :student, :cdf] begin
+    using Test
+    using AdditionalDistributions
+    using Distributions
+
+    ν = 5.0
+    μ = [2.0]
+    Σ = reshape([9.0], 1, 1)
+
+    d  = MvTStudent(ν, μ, Σ)
+    dn = MvTDist(ν, μ, Σ)
+
+    a = [-Inf]
+    b = [2.0]
+
+    # Symmetry about the location gives an exact 1/2 probability,
+    # independently of ν and the scale.
+    expected = 0.5
+
+    rn = cdf_result(dn, a, b)
+    rw = cdf_result(d, a, b)
+
+    @test rn.value ≈ expected atol=1e-14
+    @test rw.value ≈ expected atol=1e-14
+    @test rn.algorithm == :univariate_exact_t
+    @test rw.algorithm == :univariate_exact_t
+
+    @test AdditionalDistributions._cdf(dn, a, b) ≈ expected atol=1e-14
+    @test AdditionalDistributions._cdf(dn, b) ≈ expected atol=1e-14
+
+    @test cdf(d, a, b) ≈ expected atol=1e-14
+    @test cdf(d, b) ≈ expected atol=1e-14
+
+    @test_throws DimensionMismatch cdf(d, [0.0, 1.0])
+    @test_throws DimensionMismatch cdf_result(dn, [-Inf, -Inf], b)
+end
+
+
+@testitem "MvTStudent – CDF uses location and scale" tags=[:multivariate, :api, :student, :cdf] begin
+    using Test
+    using AdditionalDistributions
+    using Distributions
+
+    # ν < 1: the statistical mean is undefined, but the CDF is perfectly
+    # well-defined around the location μ.
+    ν = 0.5
+    μ = [3.0]
+    Σ = reshape([4.0], 1, 1)
+
+    d  = MvTStudent(ν, μ, Σ)
+    dn = MvTDist(ν, μ, Σ)
+
+    @test !(mean(dn) isa AbstractVector)
+
+    @test cdf_result(dn, [-Inf], μ).value ≈ 0.5 atol=1e-14
+    @test cdf(d, μ) ≈ 0.5 atol=1e-14
+end


### PR DESCRIPTION
## Summary

This PR refactors the multivariate API so that `AdditionalDistributions.jl` integrates more naturally with `Distributions.jl` while keeping the existing randomized-QMC numerical backend unchanged.

## Gaussian API

- `MvGaussian` now subtypes `Distributions.AbstractMvNormal`.
- Standard functionality such as `pdf`, `logpdf`, `rand`, `insupport`, `mode`, and `entropy` is obtained through the `AbstractMvNormal` interface.
- Only the primitive operations required by that abstraction are delegated to
the wrapped native distribution.

## Student-t API

- `MvTStudent` is explicitly typed around Distributions.AbstractMvTDist.
- The wrapper keeps using the native Student-t location and scale/scatter parameters for rectangular probabilities.
- The distinction between scale and covariance is preserved.

## Native Distributions.jl interoperability

The package-owned `cdf_result` API now works directly with native `Distributions.jl` objects:

```julia
dn = MvNormal(μ, Σ)
cdf_result(dn, lower, upper)

dt = MvTDist(ν, μ, Σ)
cdf_result(dt, lower, upper)
```
The private scalar helper _cdf supports the same native distributions.

This deliberately does not define

```julia
Distributions.cdf(::MvNormal, ...)
Distributions.cdf(::MvTDist, ...)
```
so the package does not introduce type piracy.

Package-owned wrappers continue to provide the natural scalar interface:

```julia
cdf(MvGaussian(μ, Σ), upper)
cdf(MvGaussian(μ, Σ), lower, upper)

cdf(MvTStudent(ν, μ, Σ), upper)
cdf(MvTStudent(ν, μ, Σ), lower, upper)
```

## Numerical scope

This PR does **not** redesign the multivariate integration algorithm. In particular, it does not change:

- the Genz/MVSORT preparation;
- randomized Richtmyer QMC points;
- Student-t scale-mixture integration;
- default integration budgets;
- error tolerances;
- `CDFResult.neval` semantics;
- randomized-shift defaults.

## Tests

Added API regression tests covering:

- `MvGaussian <: AbstractMvNormal;`
- agreement between `MvGaussian` and native `MvNormal`;
- agreement between `MvTStudent` and native `MvTDist`;
- direct `cdf_result` use with native multivariate distributions;
- one-sided and rectangular wrapper CDFs;
- Student-t CDF behavior when the statistical mean does not exist.

The complete package test suite passes locally.