### PR TITLE
Optimize multivariate Gaussian and Student-t QMC integration

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ description = "Additional probability distributions for Julia, implementing the 
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 HypergeometricFunctions = "34004b35-14d8-5ef3-9330-4cdb6864b03a"
 LambertW = "984bce1d-4616-540c-a9ee-88d1112d94c9"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -21,6 +22,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 [compat]
 Aqua = "0.8"
 Distributions = "0.25"
+FFTW = "1"
 ForwardDiff = "0.10, 1"
 HypergeometricFunctions = "0.3"
 LambertW = "0.4, 1"

--- a/docs/src/accuracy.md
+++ b/docs/src/accuracy.md
@@ -24,7 +24,7 @@ The returned object stores:
 | `value` | Estimated rectangular probability. |
 | `error` | Estimated randomized QMC integration error. |
 | `inform` | Integration status code. |
-| `neval` | Integration budget used. |
+| `neval` | Requested integration budget. The actual prime-rounded lattice evaluation count may be slightly smaller. |
 | `algorithm` | Internal algorithm identifier. |
 
 ## `inform` codes
@@ -82,11 +82,13 @@ Small differences across seeds are expected because the method is randomized.
 
 ## Reference comparisons
 
-Gaussian cases are tested against Genz-style reference values and comparisons with `MvNormalCDF.jl`.
+For structured Gaussian validation cases, deterministic references are used whenever available. Equicorrelated rectangles are reduced to one-dimensional quadrature, while AR(1) cases are evaluated through a deterministic Gaussian Markov recursion.
 
-Student-t cases are tested against selected values generated with R's `mvtnorm::pmvt` and the `GenzBretz` algorithm.
+For Student-t validation cases, the normal-scale-mixture representation is combined with the same deterministic Gaussian references and a one-dimensional radial integral.
 
-For difficult Student-t cases, especially with small degrees of freedom, high dimension, or strong correlation, strict tolerances such as `1e-8` may require large integration budgets and may still return `inform = 1`.
+`MvNormalCDF.jl`, SciPy, and R's `mvtnorm` are useful independent implementation comparisons, but their randomized estimates are not treated as ground truth.
+
+For difficult Student-t cases, especially with small degrees of freedom, high dimension, or strong correlation, larger integration budgets may still be required.
 
 ## Recommended reporting format
 
@@ -105,13 +107,17 @@ lower = fill(-1.0, d)
 upper = fill(1.0, d)
 
 dist = MvGaussian(zeros(d), Σ)
-# or: dist = MvTStudent(ν, zeros(d), Σ)
+nshifts = 10
+
+# For Student-t:
+# dist = MvTStudent(ν, zeros(d), Σ)
+# nshifts = 8
 
 res = cdf_result(dist, lower, upper;
     m = 1_000_000,
     abseps = 1e-8,
     releps = 1e-8,
-    nshifts = 10,
+    nshifts = nshifts,
     rng = MersenneTwister(1234),
 )
 

--- a/docs/src/accuracy.md
+++ b/docs/src/accuracy.md
@@ -57,7 +57,7 @@ For quick exploratory computations, moderate values of `m` may be enough. For pu
 Defaults:
 
 - `MvGaussian`: `nshifts = 10`;
-- `MvTStudent`: `nshifts = 16`.
+- `MvTStudent`: `nshifts = 8`.
 
 For fixed `m`, increasing `nshifts` reduces the number of points per shift. It does not always reduce the reported error. Benchmark before changing defaults.
 

--- a/docs/src/accuracy.md
+++ b/docs/src/accuracy.md
@@ -56,7 +56,7 @@ For quick exploratory computations, moderate values of `m` may be enough. For pu
 
 Defaults:
 
-- `MvGaussian`: `nshifts = 12`;
+- `MvGaussian`: `nshifts = 10`;
 - `MvTStudent`: `nshifts = 16`.
 
 For fixed `m`, increasing `nshifts` reduces the number of points per shift. It does not always reduce the reported error. Benchmark before changing defaults.
@@ -111,7 +111,7 @@ res = cdf_result(dist, lower, upper;
     m = 1_000_000,
     abseps = 1e-8,
     releps = 1e-8,
-    nshifts = 12,
+    nshifts = 10,
     rng = MersenneTwister(1234),
 )
 

--- a/docs/src/benchmarks.md
+++ b/docs/src/benchmarks.md
@@ -1,14 +1,42 @@
 # Benchmarks
 
-This page documents reproducible benchmark scripts for the multivariate rectangular CDF routines in `AdditionalDistributions.jl`.
+This page documents the numerical validation used for the multivariate rectangular CDF routines in `AdditionalDistributions.jl`.
 
-The goal of these benchmarks is not to claim universal superiority over other implementations. Randomized quasi-Monte Carlo algorithms depend on dimension, covariance structure, integration region, integration budget, random seed, Julia version, package versions, and hardware.
+The goal is not to claim universal superiority over other implementations. Randomized quasi-Monte Carlo performance depends on dimension, dependence structure, integration region, evaluation budget, randomization, package versions, and hardware. The results below document representative development validation for the current numerical defaults.
 
-Instead, these scripts provide reproducible empirical comparisons for specific configurations.
+Generated benchmark CSV files and the larger cross-language experimental harnesses are development artifacts and are intentionally not committed to the package repository.
 
-## Available scripts
+## Numerical backend
 
-Benchmark scripts live in the `benchmark/` directory.
+For correlated Gaussian rectangles, the default floating-point path uses:
+
+1. MVSORT variable reordering;
+2. the Genz conditional transformation;
+3. a component-by-component (CBC) rank-1 lattice;
+4. randomized shifts and tent transformation;
+5. cached lattice generating vectors;
+6. batched integrand evaluation.
+
+The Gaussian QMC dimension is `d - 1`. Diagonal Gaussian covariance matrices are handled by an exact product shortcut.
+
+For multivariate Student-t rectangles, the same conditional Gaussian construction is augmented by one radial chi-square coordinate from the normal-scale-mixture representation. The QMC dimension is therefore `d`. The radial coordinate and the conditional Gaussian coordinates both use the tent transformation.
+
+For common Student-t degrees of freedom, the radial scaling code also has specialized paths for `ν = 1`, `ν = 2`, and `ν = 4`.
+
+The current default numbers of randomized shifts are:
+
+```julia
+MvGaussian:  nshifts = 10
+MvTStudent:  nshifts = 8
+```
+
+For the default floating-point path, the CBC lattice length is chosen as a prime not exceeding the available per-shift budget and the resulting generating vector is cached. Very small budgets and non-floating scalar types retain a Richtmyer fallback.
+
+Because the lattice length is prime-rounded, the actual number of lattice evaluations can be slightly smaller than the nominal integration budget. `CDFResult.neval` retains the requested-budget convention for API compatibility.
+
+## Committed benchmark scripts
+
+Smaller package benchmarks live in the `benchmark/` directory.
 
 ### Basic multivariate Gaussian benchmark
 
@@ -16,128 +44,152 @@ Benchmark scripts live in the `benchmark/` directory.
 julia --project=benchmark benchmark/run_mvn_basic.jl
 ```
 
-This runs package-only benchmarks for `MvGaussian` rectangular probabilities.
-
 ### Comparison with `MvNormalCDF.jl`
 
 ```bash
 julia --project=benchmark benchmark/run_mvn_compare_mvnormalcdf.jl
 ```
 
-This benchmark compares `AdditionalDistributions.MvGaussian` against `MvNormalCDF.jl` for rectangular Gaussian probabilities under several covariance structures:
+Generated result files should be written under `benchmark/results/` and should not be committed.
 
-- diagonal covariance;
-- equicorrelated covariance;
-- AR(1)-type covariance.
+## Development validation environment
 
-The benchmark reports:
+The tables below were produced on the following single-threaded environment:
 
-- probability estimate;
-- estimated integration error;
-- integration status;
-- runtime;
-- memory allocations.
+- Apple M4;
+- 16 GiB RAM;
+- Julia 1.12.6;
+- Python 3.13.3;
+- SciPy 1.18.1;
+- NumPy 2.5.2;
+- R 4.5.3;
+- `mvtnorm` 1.3.3.
 
-Generated CSV files are written under:
+Five randomized seeds were used for each stochastic method. The nominal budgets were `10_000` and `100_000`. AdditionalDistributions.jl and R `mvtnorm` were run with zero absolute and relative stopping tolerances so that the nominal budget controlled the run. SciPy was evaluated through its public multivariate CDF interfaces with the corresponding `maxpts` budget. Actual internal evaluation counts may therefore differ slightly across implementations.
 
-```text
-benchmark/results/
-```
+Runtime values are medians. Julia allocation measurements are reported only for Julia implementations; allocation numbers are not compared across languages.
 
-These generated result files should not be committed.
+## Independent reference probabilities
 
-## Representative Gaussian results
+Accuracy was evaluated against structured deterministic references rather than treating any competing QMC implementation as ground truth.
 
-The current `MvGaussian` implementation uses a Genz-style conditional transformation, folded randomized Richtmyer QMC points, and batched evaluation. Diagonal Gaussian rectangles are evaluated by an exact product shortcut.
+### Gaussian battery
 
-In local benchmark runs, `AdditionalDistributions.jl` produced probability estimates matching `MvNormalCDF.jl` closely in the tested Gaussian cases, while often using less memory.
+The Gaussian battery contains 48 cases:
 
-Representative local timings from development runs were:
+- dimensions `d ∈ {3, 10, 20, 50}`;
+- equicorrelation and AR(1) dependence;
+- `ρ ∈ {0.3, 0.95}`;
+- central, lower-tail, and mixed rectangles.
 
-| Case | AdditionalDistributions.jl | MvNormalCDF.jl | Notes |
-| --- | ---: | ---: | --- |
-| `d = 2`, equicorrelated `ρ = 0.2` | ≈ `0.0028s` | ≈ `0.0036s` | same probability/error order |
-| `d = 5`, equicorrelated `ρ = 0.5` | ≈ `0.0155s` | ≈ `0.0179s` | same probability/error order |
-| `d = 10`, equicorrelated `ρ = 0.2` | ≈ `0.0299s` | ≈ `0.0370s` | same probability/error order |
-| `d = 20`, AR(1) `ρ = 0.2` | ≈ `0.0600s` | ≈ `0.0712s` | same probability/error order |
+For equicorrelation, the common-factor representation reduces each multivariate Gaussian rectangle to deterministic one-dimensional quadrature.
 
-These numbers are illustrative development results, not a performance guarantee. Run the benchmark scripts on your own machine for reproducible comparisons.
+For AR(1), the Gaussian Markov property reduces the rectangle probability to a sequence of one-dimensional transition integrals evaluated by deterministic Gauss-Legendre quadrature.
 
-## Student-t reference comparison
+All 48 Gaussian reference cases passed the reference-convergence checks.
 
-For `MvTStudent`, benchmark-style reference checks can be performed against R's `mvtnorm::pmvt` using the `GenzBretz` algorithm.
+### Student-t battery
 
-For example, in R:
+The Student-t battery contains 72 cases:
 
-```r
-library(mvtnorm)
+- dimensions `d ∈ {3, 10}`;
+- equicorrelation and AR(1) dependence;
+- `ρ ∈ {0.3, 0.95}`;
+- `ν ∈ {1, 4, 10}`;
+- central, lower-tail, and mixed rectangles.
 
-d <- 10
-rho <- 0.5
-corr <- matrix(rho, d, d)
-diag(corr) <- 1
+The Student-t scale-mixture identity is used to integrate over the radial chi-square variable. Conditional on the radial scale, the inner Gaussian rectangle is evaluated by the deterministic equicorrelation or AR(1) reference described above.
 
-set.seed(1234)
+All 72 Student-t reference cases passed the reference-convergence checks.
 
-p <- pmvt(
-  lower = rep(-1, d),
-  upper = rep(1, d),
-  df = 4,
-  corr = corr,
-  algorithm = GenzBretz(
-    maxpts = 1000000,
-    abseps = 1e-8,
-    releps = 1e-8
-  )
-)
+## Gaussian results
 
-print(p)
-print(attributes(p))
-```
+The following table summarizes the complete 48-case battery. `med|err|`, RMSE, and `p90` are based on absolute error against the deterministic reference.
 
-A representative comparison for this case is:
+| Nominal budget | Method | med\|err\| | RMSE | p90 | Median time | Julia allocations |
+| ---: | --- | ---: | ---: | ---: | ---: | ---: |
+| 10,000 | AdditionalDistributions.jl | `8.72e-7` | `6.78e-5` | `7.20e-5` | `5.654 ms` | `0.159 MiB` |
+| 10,000 | MvNormalCDF.jl | `3.91e-6` | `1.61e-4` | `2.50e-4` | `6.439 ms` | `0.188 MiB` |
+| 10,000 | SciPy | `1.10e-6` | `7.65e-5` | `8.28e-5` | `10.393 ms` | — |
+| 10,000 | R `mvtnorm` | `2.06e-6` | `1.09e-4` | `1.56e-4` | `27.000 ms` | — |
+| 100,000 | AdditionalDistributions.jl | `1.13e-7` | `1.55e-5` | `2.41e-5` | `56.394 ms` | `0.364 MiB` |
+| 100,000 | MvNormalCDF.jl | `9.40e-7` | `3.97e-5` | `5.43e-5` | `64.086 ms` | `1.563 MiB` |
+| 100,000 | SciPy | `1.75e-7` | `1.67e-5` | `2.03e-5` | `83.352 ms` | — |
+| 100,000 | R `mvtnorm` | `3.90e-7` | `8.73e-5` | `7.90e-5` | `85.500 ms` | — |
 
-```text
-R mvtnorm::pmvt:
-value ≈ 0.1087057
-error ≈ 9.12e-6
+Case-wise paired comparisons use the median absolute error across the five seeds for each problem.
 
-AdditionalDistributions.jl:
-value ≈ 0.1087074
-error ≈ 1.46e-5
-```
+| Budget | Comparison | AD wins | Other wins | Unresolved | Median paired error ratio AD/other |
+| ---: | --- | ---: | ---: | ---: | ---: |
+| 10,000 | vs MvNormalCDF.jl | 45 | 2 | 1 | `0.3292` |
+| 10,000 | vs SciPy | 22 | 25 | 1 | `1.1000` |
+| 10,000 | vs R `mvtnorm` | 30 | 16 | 2 | `0.6502` |
+| 100,000 | vs MvNormalCDF.jl | 43 | 4 | 1 | `0.2712` |
+| 100,000 | vs SciPy | 30 | 15 | 3 | `0.6675` |
+| 100,000 | vs R `mvtnorm` | 43 | 3 | 2 | `0.2606` |
 
-Both methods may report that the requested tolerance was not fully reached when strict tolerances such as `1e-8` are used.
+At the larger budget, AdditionalDistributions.jl has lower paired median error than SciPy in 30 cases versus 15 for SciPy, while also having lower median runtime in this environment. SciPy retains a slightly lower absolute-error `p90` at this budget, so the result should be interpreted as a favorable accuracy/runtime trade-off rather than universal dominance.
+
+## Student-t results
+
+The following table summarizes the complete 72-case Student-t battery.
+
+| Nominal budget | Method | med\|err\| | RMSE | p90 | Median relative error | Median time | Julia allocations |
+| ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 10,000 | AdditionalDistributions.jl | `8.71e-6` | `1.09e-4` | `1.10e-4` | `9.43e-5` | `4.383 ms` | `0.109 MiB` |
+| 10,000 | SciPy | `8.99e-6` | `1.12e-4` | `1.57e-4` | `1.10e-4` | `7.266 ms` | — |
+| 10,000 | R `mvtnorm` | `1.27e-5` | `1.06e-4` | `1.17e-4` | `1.53e-4` | `22.500 ms` | — |
+| 100,000 | AdditionalDistributions.jl | `7.14e-7` | `1.36e-5` | `1.28e-5` | `7.45e-6` | `44.488 ms` | `0.199 MiB` |
+| 100,000 | SciPy | `6.74e-7` | `1.71e-5` | `1.42e-5` | `8.61e-6` | `65.324 ms` | — |
+| 100,000 | R `mvtnorm` | `2.81e-6` | `4.87e-5` | `5.82e-5` | `2.73e-5` | `94.000 ms` | — |
+
+Case-wise paired comparisons are:
+
+| Budget | Comparison | AD wins | Other wins | Unresolved | Median paired error ratio AD/other |
+| ---: | --- | ---: | ---: | ---: | ---: |
+| 10,000 | vs SciPy | 38 | 34 | 0 | `0.9330` |
+| 10,000 | vs R `mvtnorm` | 45 | 27 | 0 | `0.7065` |
+| 100,000 | vs SciPy | 42 | 30 | 0 | `0.8985` |
+| 100,000 | vs R `mvtnorm` | 69 | 3 | 0 | `0.2541` |
+
+The specialized radial paths are visible in runtime by degrees of freedom. At a nominal budget of `100_000`, median AdditionalDistributions.jl runtimes across case-level medians were approximately `21.2 ms` for `ν = 1`, `28.6 ms` for `ν = 4`, and `77.9 ms` for the generic `ν = 10` path. The generic chi-square inverse remains a potential future optimization target, but it is not part of the numerical changes documented here.
+
+## Interpreting QMC error estimates
+
+`CDFResult.error` is a randomized-QMC uncertainty estimate, not a deterministic mathematical error bound.
+
+The validation tables above therefore use the actual absolute or relative discrepancy from an independent deterministic reference whenever the structured reference is available. A small reported QMC error should not by itself be interpreted as proof that the returned probability is equally accurate.
+
+`inform = 1` means that the internal estimated error is above the requested tolerance for the available budget. It does not automatically imply that the probability estimate is unusable.
 
 ## Reproducibility checklist
 
-When reporting benchmark results, include:
+When reporting a multivariate CDF benchmark, include:
 
-- Julia version;
-- package versions;
+- package and language versions;
 - operating system and CPU;
-- distribution type;
-- dimension;
-- covariance/correlation matrix;
-- integration lower and upper bounds;
+- number of execution threads;
+- distribution and dimension;
+- covariance or scale matrix;
+- integration bounds;
 - degrees of freedom for Student-t;
-- `m`;
-- `abseps`;
-- `releps`;
+- nominal integration budget `m`;
 - `nshifts`;
-- `batchsize`;
+- `abseps` and `releps`;
 - random seed;
-- runtime;
-- allocations;
+- runtime methodology;
+- allocations when comparable;
 - `CDFResult.value`;
 - `CDFResult.error`;
-- `CDFResult.inform`.
+- `CDFResult.inform`;
+- the source and uncertainty of any external reference probability.
 
-A minimal reproducible Julia example should look like:
+A minimal Gaussian call is:
 
 ```julia
 using AdditionalDistributions
-using Random, LinearAlgebra
+using LinearAlgebra
+using Random
 
 d = 10
 ρ = 0.5
@@ -149,15 +201,14 @@ upper = fill(1.0, d)
 
 dist = MvGaussian(zeros(d), Σ)
 
-res = cdf_result(dist, lower, upper;
-    m = 1_000_000,
-    abseps = 1e-8,
-    releps = 1e-8,
+res = cdf_result(
+    dist,
+    lower,
+    upper;
+    m = 100_000,
     nshifts = 10,
     rng = MersenneTwister(1234),
 )
-
-res
 ```
 
 For Student-t:
@@ -166,21 +217,18 @@ For Student-t:
 ν = 4.0
 dist = MvTStudent(ν, zeros(d), Σ)
 
-res = cdf_result(dist, lower, upper;
-    m = 1_000_000,
-    abseps = 1e-8,
-    releps = 1e-8,
+res = cdf_result(
+    dist,
+    lower,
+    upper;
+    m = 100_000,
     nshifts = 8,
     rng = MersenneTwister(1234),
 )
-
-res
 ```
 
-## Interpretation
+## Algorithm references
 
-The reported `error` is an internal randomized QMC error estimate, not a deterministic mathematical bound.
+The conditional Gaussian transformation follows the approach of Alan Genz, *Numerical Computation of Multivariate Normal Probabilities*, Journal of Computational and Graphical Statistics 1(2), 1992, DOI `10.1080/10618600.1992.10477010`.
 
-The status code `inform = 1` means that the estimated error is still above the requested tolerance for the current integration budget. It does not automatically mean that the probability estimate is unusable.
-
-For difficult cases, increase `m`, use a fixed seed, and compare with an external reference implementation when possible.
+The fast component-by-component construction follows the rank-1 lattice methodology described by Dirk Nuyens and Ronald Cools, *Fast Component-by-Component Construction, a Reprise for Different Kernels*, in *Monte Carlo and Quasi-Monte Carlo Methods 2004*, 2006, DOI `10.1007/3-540-31186-6_22`.

--- a/docs/src/benchmarks.md
+++ b/docs/src/benchmarks.md
@@ -153,7 +153,7 @@ res = cdf_result(dist, lower, upper;
     m = 1_000_000,
     abseps = 1e-8,
     releps = 1e-8,
-    nshifts = 12,
+    nshifts = 10,
     rng = MersenneTwister(1234),
 )
 

--- a/docs/src/benchmarks.md
+++ b/docs/src/benchmarks.md
@@ -170,7 +170,7 @@ res = cdf_result(dist, lower, upper;
     m = 1_000_000,
     abseps = 1e-8,
     releps = 1e-8,
-    nshifts = 16,
+    nshifts = 8,
     rng = MersenneTwister(1234),
 )
 

--- a/docs/src/bestiary/multivariate.md
+++ b/docs/src/bestiary/multivariate.md
@@ -63,7 +63,7 @@ res = cdf_result(mvt, lower, upper;
     m = 1_000_000,
     abseps = 1e-8,
     releps = 1e-8,
-    nshifts = 16,
+    nshifts = 8,
     rng = MersenneTwister(1234),
 )
 ```
@@ -87,7 +87,7 @@ rn = cdf_result(dn, lower, upper;
 dt = MvTDist(ν, zeros(d), Σ)
 rt = cdf_result(dt, lower, upper;
     m = 1_000_000,
-    nshifts = 16,
+    nshifts = 8,
     rng = MersenneTwister(1234),
 )
 ```
@@ -139,7 +139,7 @@ res.algorithm
 | `abseps` | Absolute error tolerance. |
 | `releps` | Relative error tolerance. |
 | `rng` | Random number generator for randomized shifts. |
-| `nshifts` | Number of randomized QMC shifts. Defaults: `10` for Gaussian, `16` for Student-t. |
+| `nshifts` | Number of randomized QMC shifts. Defaults: `10` for Gaussian, `8` for Student-t. |
 | `batchsize` | Internal batch size. Automatic settings are usually appropriate. |
 | `pivot` | Enable or disable MVSORT reordering. |
 | `antithetic` | Optional antithetic reflection when available. |
@@ -151,7 +151,7 @@ res = cdf_result(mvt, lower, upper;
     m = 1_000_000,
     abseps = 1e-8,
     releps = 1e-8,
-    nshifts = 16,
+    nshifts = 8,
     rng = MersenneTwister(1234),
 )
 ```
@@ -208,7 +208,7 @@ The default settings for `MvTStudent` are more conservative:
 
 ```julia
 m = max(100_000, 10_000*d)
-nshifts = 16
+nshifts = 8
 ```
 
 Important: a diagonal Student-t scale matrix does not imply independent components. The components share a common radial scale, so diagonal Student-t rectangular probabilities are not computed as products of univariate Student-t probabilities.

--- a/docs/src/bestiary/multivariate.md
+++ b/docs/src/bestiary/multivariate.md
@@ -139,7 +139,7 @@ res.algorithm
 | `abseps` | Absolute error tolerance. |
 | `releps` | Relative error tolerance. |
 | `rng` | Random number generator for randomized shifts. |
-| `nshifts` | Number of randomized QMC shifts. Defaults: `12` for Gaussian, `16` for Student-t. |
+| `nshifts` | Number of randomized QMC shifts. Defaults: `10` for Gaussian, `16` for Student-t. |
 | `batchsize` | Internal batch size. Automatic settings are usually appropriate. |
 | `pivot` | Enable or disable MVSORT reordering. |
 | `antithetic` | Optional antithetic reflection when available. |
@@ -183,7 +183,7 @@ Diagonal Gaussian covariance/correlation matrices are handled by an exact produc
 The default number of randomized shifts is:
 
 ```julia
-nshifts = 12
+nshifts = 10
 ```
 
 ### Student-t path

--- a/docs/src/bestiary/multivariate.md
+++ b/docs/src/bestiary/multivariate.md
@@ -175,7 +175,7 @@ The Gaussian rectangular CDF uses:
 
 1. MVSORT variable reordering;
 2. Genz-style conditional transformation;
-3. folded randomized Richtmyer quasi-Monte Carlo points;
+3. a cached CBC rank-1 lattice with randomized shifts and tent-transformed coordinates;
 4. batched evaluation to reduce per-point overhead.
 
 Diagonal Gaussian covariance/correlation matrices are handled by an exact product shortcut.
@@ -185,6 +185,8 @@ The default number of randomized shifts is:
 ```julia
 nshifts = 10
 ```
+
+For the default floating-point path, the Gaussian QMC dimension is `d - 1`. A prime-length CBC rank-1 lattice is selected from the available per-shift budget and its generating vector is cached. Very small budgets and non-floating scalar types retain a Richtmyer fallback.
 
 ### Student-t path
 
@@ -202,16 +204,20 @@ X = \mu + \frac{Z}{\sqrt{W/\nu}}
 
 has a multivariate Student-t distribution.
 
-The algorithm uses the same conditional Gaussian core together with one radial chi-square coordinate. The Gaussian coordinates are folded; the chi-square radial coordinate is not folded.
+The algorithm uses the same conditional Gaussian core together with one radial chi-square coordinate. Both the radial coordinate and the conditional Gaussian coordinates use the tent transformation.
 
-The default settings for `MvTStudent` are more conservative:
+The default settings for `MvTStudent` are:
 
 ```julia
 m = max(100_000, 10_000*d)
 nshifts = 8
 ```
 
+The Student-t QMC dimension is `d`: one radial coordinate plus `d - 1` conditional Gaussian coordinates.
+
 Important: a diagonal Student-t scale matrix does not imply independent components. The components share a common radial scale, so diagonal Student-t rectangular probabilities are not computed as products of univariate Student-t probabilities.
+
+Because the CBC lattice length is prime-rounded, the actual number of lattice evaluations can be slightly smaller than the nominal budget. `CDFResult.neval` retains the requested-budget convention for API compatibility.
 
 ## Reproducibility
 

--- a/docs/src/developer.md
+++ b/docs/src/developer.md
@@ -65,9 +65,9 @@ The internal multivariate CDF entry point is `mvtcdf`. It prepares limits and co
 Important implementation choices:
 
 - Gaussian diagonal rectangles are evaluated exactly by factorization.
-- Gaussian correlated rectangles use folded randomized Richtmyer QMC.
+- Correlated Gaussian rectangles use a cached CBC rank-1 lattice with random shifts and tent transformation.
 - Student-t rectangles use the normal-scale-mixture representation and add one chi-square coordinate.
-- The chi-square coordinate is not folded.
+- Student-t uses the same tent transformation for the radial chi-square coordinate and the conditional Gaussian coordinates.
 - Diagonal Student-t scale matrices must not be treated as products of independent univariate Student-t probabilities.
 - `inform = 1` should be propagated to users rather than suppressed.
 
@@ -80,9 +80,9 @@ Reference tests should include:
 - tolerances justified by the reference method;
 - enough metadata to regenerate the value.
 
-For Gaussian rectangular probabilities, Genz-style examples and `MvNormalCDF.jl` comparisons are useful.
+For structured Gaussian benchmark cases, prefer deterministic references when available. Equicorrelation admits a one-factor reduction to one-dimensional quadrature, while AR(1) dependence admits a deterministic Gaussian Markov recursion. `MvNormalCDF.jl`, SciPy, and R's `mvtnorm` are useful cross-implementation checks, but their randomized estimates should not be treated as ground truth.
 
-For Student-t rectangular probabilities, R's `mvtnorm::pmvt` with `GenzBretz` can be used as an external reference.
+For Student-t benchmark cases, the normal-scale-mixture representation can be combined with the same deterministic Gaussian reference calculations and a one-dimensional radial integral. SciPy and R's `mvtnorm::pmvt` remain useful independent implementation comparisons.
 
 ## Benchmarks
 

--- a/src/AdditionalDistributions.jl
+++ b/src/AdditionalDistributions.jl
@@ -4,6 +4,7 @@ using Distributions
 import Distributions: @check_args, @distr_support, @inline, params, partype
 import Roots
 import SpecialFunctions
+import FFTW
 import Random
 import Base: @propagate_inbounds
 import Statistics
@@ -18,6 +19,7 @@ import Primes
 const normal_dist = Distributions.Normal()
 const sqrt2π = sqrt(2.0 * π)
 
+include("multivariate/QMCLattice.jl")
 include("utils.jl")
 
 # ─────────────────────────────────────────────────────────────

--- a/src/multivariate/MvGaussian.jl
+++ b/src/multivariate/MvGaussian.jl
@@ -3,7 +3,7 @@
 
 A multivariate Gaussian distribution backed by `Distributions.AbstractMvNormal`,
 with rectangular cumulative probabilities evaluated by the custom
-Genz/Richtmyer randomized quasi-Monte Carlo backend in
+Genz-style randomized rank-1 lattice quasi-Monte Carlo backend in
 `AdditionalDistributions.jl`.
 
 `MvGaussian` participates in the `Distributions.jl` `AbstractMvNormal`

--- a/src/multivariate/MvGaussian.jl
+++ b/src/multivariate/MvGaussian.jl
@@ -84,7 +84,7 @@ Distributions._rand!(
     cdf_result(d::Distributions.AbstractMvNormal, a, b;
                m=1000*length(a), abseps=1e-6, releps=1e-6,
                pivot=true, rng=Random.default_rng(),
-               antithetic=false, batchsize=0, nshifts=12)
+               antithetic=false, batchsize=0, nshifts=10)
 
 Estimate the rectangular probability `P(a ≤ X ≤ b)` for any
 `Distributions.AbstractMvNormal` and return a [`CDFResult`](@ref).
@@ -104,7 +104,7 @@ function cdf_result(
     rng=Random.default_rng(),
     antithetic::Bool=false,
     batchsize::Int=0,
-    nshifts::Int=12,
+    nshifts::Int=10,
 )
     n = length(d)
 

--- a/src/multivariate/MvStudent.jl
+++ b/src/multivariate/MvStudent.jl
@@ -3,7 +3,7 @@
 
 A multivariate Student's t distribution backed by a native
 `Distributions.AbstractMvTDist`, with rectangular cumulative probabilities
-evaluated by the custom Genz-Bretz/Richtmyer randomized QMC backend in
+evaluated by the custom Genz-style randomized rank-1 lattice QMC backend in
 `AdditionalDistributions.jl`.
 
 `Σ` is the scale/scatter matrix used by `Distributions.MvTDist`; it is not

--- a/src/multivariate/MvStudent.jl
+++ b/src/multivariate/MvStudent.jl
@@ -100,7 +100,7 @@ partype(d::MvTStudent) = partype(d.dist)
                m=max(100_000, 10_000*length(a)),
                abseps=1e-6, releps=1e-6, pivot=true,
                rng=Random.default_rng(), antithetic=false,
-               batchsize=0, nshifts=16)
+               batchsize=0, nshifts=8)
 
 Estimate `P(a ≤ X ≤ b)` for a native `Distributions.AbstractMvTDist` and
 return a [`CDFResult`](@ref).
@@ -119,7 +119,7 @@ function cdf_result(
     rng=Random.default_rng(),
     antithetic::Bool=false,
     batchsize::Int=0,
-    nshifts::Int=16,
+    nshifts::Int=8,
 )
     n = length(d)
 

--- a/src/multivariate/QMCLattice.jl
+++ b/src/multivariate/QMCLattice.jl
@@ -152,16 +152,14 @@ function _cached_cbc_lattice(::Type{T}, qdim::Int, requested_nper::Int,) where {
     end
 end
 
-"""
-    _qmc_lattice(T, qdim, requested_nper)
-
-Return `(α, nper)` for the internal randomized rank-1 lattice.
-
-For ordinary floating-point calculations and at least three requested
-points per random shift, a cached Fast-CBC lattice is used. Very small
-budgets and non-floating scalar types retain the previous Richtmyer rule
-as a compatibility fallback.
-"""
+#     _qmc_lattice(T, qdim, requested_nper)
+#
+# Return `(α, nper)` for the internal randomized rank-1 lattice.
+#
+# For ordinary floating-point calculations and at least three requested
+# points per random shift, a cached Fast-CBC lattice is used. Very small
+# budgets and non-floating scalar types retain the previous Richtmyer rule
+# as a compatibility fallback.
 function _qmc_lattice(::Type{T}, qdim::Int, requested_nper::Int,) where {T<:AbstractFloat}
     qdim <= 0 && return T[], requested_nper
 

--- a/src/multivariate/QMCLattice.jl
+++ b/src/multivariate/QMCLattice.jl
@@ -1,0 +1,177 @@
+# ─────────────────────────────────────────────────────────────
+# Fast component-by-component (CBC) rank-1 lattice construction
+# ─────────────────────────────────────────────────────────────
+#
+# The randomized QMC integrators use a rank-1 lattice with a generating
+# vector selected component-by-component. The CBC objective uses the
+# Bernoulli-polynomial kernel employed by modern Genz-style implementations.
+#
+# Construction is accelerated with FFTs and cached by (floating type, qdim,
+# prime points per random shift). The FFT work is therefore paid only on the
+# first request for a given lattice.
+#
+# Reference:
+#   Nuyens, D. and Cools, R. (2006).
+#   Fast component-by-component construction, a reprise for different kernels.
+#   Monte Carlo and Quasi-Monte Carlo Methods 2004, 371–385.
+# ─────────────────────────────────────────────────────────────
+
+const _CBC_LATTICE_CACHE = Dict{Tuple{DataType,Int,Int},Any}()
+const _CBC_LATTICE_CACHE_LOCK = ReentrantLock()
+
+@inline function _cbc_powermod(a::Int, e::Int, m::Int)
+    result = 1
+    base = mod(a, m)
+    exponent = e
+
+    while exponent > 0
+        if isodd(exponent)
+            result = Int(mod(Int128(result) * base, m))
+        end
+
+        exponent >>= 1
+
+        if exponent > 0
+            base = Int(mod(Int128(base) * base, m))
+        end
+    end
+
+    return result
+end
+
+function _cbc_primitive_root_prime(p::Int)
+    p >= 3 || throw(ArgumentError("CBC prime must be at least 3"))
+    Primes.isprime(p) ||
+        throw(ArgumentError("CBC modulus must be prime"))
+
+    factors = keys(Primes.factor(p - 1))
+
+    for g in 2:(p - 1)
+        good = true
+
+        for q in factors
+            if _cbc_powermod(g, (p - 1) ÷ q, p) == 1
+                good = false
+                break
+            end
+        end
+
+        good && return g
+    end
+
+    error("primitive root not found for prime $p")
+end
+
+function _fast_cbc_lattice_float64(qdim::Int, requested_nper::Int,)
+    qdim >= 1 || throw(ArgumentError("qdim must be positive"))
+    requested_nper >= 3 || throw(ArgumentError("requested_nper must be at least 3"))
+
+    p = Int(Primes.prevprime(requested_nper))
+    m = (p - 1) ÷ 2
+    g = _cbc_primitive_root_prime(p)
+
+    perm = Vector{Int}(undef, m)
+    perm[1] = 1
+
+    @inbounds for j in 2:m
+        perm[j] = mod(g * perm[j - 1], p)
+    end
+
+    @inbounds for j in 1:m
+        perm[j] = min(perm[j], p - perm[j])
+    end
+
+    invp = inv(Float64(p))
+    kernel = Vector{Float64}(undef, m)
+
+    @inbounds for j in 1:m
+        x = perm[j] * invp
+        kernel[j] = x * x - x + 1 / 6
+    end
+
+    kernel_fft = FFTW.fft(kernel)
+
+    product_weights = ones(Float64, m)
+    reordered = similar(kernel)
+    z = ones(Int, qdim)
+
+    w = 0
+
+    for s in 2:qdim
+        @inbounds for j0 in 0:(m - 1)
+            reordered[j0 + 1] =
+                kernel[mod(w - j0, m) + 1]
+        end
+
+        γ = s <= 3 ? 1.0 : 0.8^(s - 3)
+
+        @inbounds @simd for j in 1:m
+            product_weights[j] *= 1 + γ * reordered[j]
+        end
+
+        objective = real.(FFTW.ifft(kernel_fft .* FFTW.fft(product_weights)))
+
+        minval = minimum(objective)
+        tol = 128 * eps(Float64) * max(1.0, abs(minval))
+
+        candidates = findall(x -> x <= minval + tol, objective)
+
+        w = maximum(candidates) - 1
+        z[s] = perm[w + 1]
+    end
+
+    α = Float64.(z) ./ p
+    return α, p
+end
+
+function _cached_cbc_lattice(::Type{T}, qdim::Int, requested_nper::Int,) where {T<:AbstractFloat}
+    p = Int(Primes.prevprime(requested_nper))
+    key = (T, qdim, p)
+
+    lock(_CBC_LATTICE_CACHE_LOCK)
+    try
+        if haskey(_CBC_LATTICE_CACHE, key)
+            return _CBC_LATTICE_CACHE[key], p
+        end
+    finally
+        unlock(_CBC_LATTICE_CACHE_LOCK)
+    end
+
+    α64, actual_p = _fast_cbc_lattice_float64(qdim, requested_nper,)
+
+    @assert actual_p == p
+
+    α = T.(α64)
+
+    lock(_CBC_LATTICE_CACHE_LOCK)
+    try
+        cached = get!(_CBC_LATTICE_CACHE, key, α,)
+        return cached, p
+    finally
+        unlock(_CBC_LATTICE_CACHE_LOCK)
+    end
+end
+
+"""
+    _qmc_lattice(T, qdim, requested_nper)
+
+Return `(α, nper)` for the internal randomized rank-1 lattice.
+
+For ordinary floating-point calculations and at least three requested
+points per random shift, a cached Fast-CBC lattice is used. Very small
+budgets and non-floating scalar types retain the previous Richtmyer rule
+as a compatibility fallback.
+"""
+function _qmc_lattice(::Type{T}, qdim::Int, requested_nper::Int,) where {T<:AbstractFloat}
+    qdim <= 0 && return T[], requested_nper
+
+    if requested_nper < 3
+        return (richtmyer_roots(T, qdim + 1), requested_nper,)
+    end
+
+    return _cached_cbc_lattice(T, qdim, requested_nper,)
+end
+
+function _qmc_lattice(::Type{T}, qdim::Int, requested_nper::Int,) where {T<:Real}
+    return (richtmyer_roots(T, qdim + 1), requested_nper,)
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -30,35 +30,90 @@
 # χ² → scale for t: R = sqrt(χ²_ν / ν).
 # The hot MVT path passes the Chisq distribution and invsqrtν explicitly to
 # avoid constructing Chisq(ν) at every QMC point.
-@inline function _scale_t(ν::Real, u::T) where {T<:Real}
+# Exact radial transform for ν = 4.
+#
+# If X ~ χ²₄, then Y = X/2 ~ Gamma(2, 1), with
+#
+#     F_Y(y) = 1 - exp(-y)(1+y).
+#
+# Solving F_Y(y) = u gives
+#
+#     y = -1 - W₋₁(-(1-u)/e),
+#
+# and therefore
+#
+#     sqrt(X/4) = sqrt(y/2).
+#
+# Near u = 0, evaluate 1 + W₋₁ close to its branch point
+# directly with lambertwbp to avoid catastrophic cancellation.
+@inline function _scale_t_nu4(
+    χ::Distributions.Chisq,
+    invsqrtν::T,
+    u::T,
+) where {T<:AbstractFloat}
+
+    # Extremely small probabilities are essentially impossible in the
+    # randomized QMC loop, but using the generic χ² quantile here preserves
+    # full robustness when u approaches the smallest representable number.
+    if u < sqrt(floatmin(T))
+        return sqrt(T(Distributions.quantile(χ, u))) * invsqrtν
+    end
+
+    inv_e = exp(-one(T))
+
+    if u <= T(0.5)
+        # lambertwbp(z, -1) = 1 + W₋₁(-1/e + z),
+        # and -(1-u)/e = -1/e + u/e.
+        v = LambertW.lambertwbp(u * inv_e, -1)
+        return sqrt(-T(v) / T(2))
+    else
+        w = LambertW.lambertw(
+            -(one(T) - u) * inv_e,
+            -1,
+        )
+        return sqrt((-one(T) - T(w)) / T(2))
+    end
+end
+
+@inline function _scale_t(ν::Real, u::T) where {T<:AbstractFloat}
     @assert ν > 0
 
     if ν == 1
         # χ²₁ quantile:
-        # Q(u) = 2 * erfinv(u)^2.
-        # Since u ∈ (0, 1), erfinv(u) ≥ 0, hence
         # sqrt(Q(u)) = sqrt(2) * erfinv(u).
         return sqrt(T(2)) * T(SpecialFunctions.erfinv(u))
     elseif ν == 2
-        # χ²₂ ~ Exponential(scale=2), so
-        # sqrt(Q(u) / 2) = sqrt(-log(1-u)).
+        # χ²₂ ~ Exponential(scale=2):
+        # sqrt(Q(u)/2) = sqrt(-log(1-u)).
         return sqrt(-log1p(-u))
+    elseif ν == 4
+        χ = Distributions.Chisq(ν)
+        return _scale_t_nu4(
+            χ,
+            inv(sqrt(T(ν))),
+            u,
+        )
     end
 
-    return sqrt(T(Distributions.quantile(Distributions.Chisq(ν), u)) / T(ν))
+    return sqrt(
+        T(Distributions.quantile(Distributions.Chisq(ν), u)) / T(ν)
+    )
 end
 
 @inline function _scale_t(
     χ::Distributions.Chisq,
     invsqrtν::T,
     u::T,
-) where {T<:Real}
+) where {T<:AbstractFloat}
+
     ν = Distributions.dof(χ)
 
     if ν == 1
         return sqrt(T(2)) * T(SpecialFunctions.erfinv(u))
     elseif ν == 2
         return sqrt(-log1p(-u))
+    elseif ν == 4
+        return _scale_t_nu4(χ, invsqrtν, u)
     end
 
     return sqrt(T(Distributions.quantile(χ, u))) * invsqrtν

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,7 +1,7 @@
 # ─────────────────────────────────────────────────────────────
 # Multivariate rectangular probabilities: MVN / MVT
 #
-# Pure Julia implementation of the Genz-Bretz/Richtmyer randomized
+# Pure Julia implementation of randomized Genz-style rank-1 lattice
 # quasi-Monte Carlo scheme. The core is specialized for the two relevant
 # cases:
 #   - ν <= 0 : multivariate Gaussian
@@ -14,7 +14,7 @@
 #   4. QMC generation and integrand evaluation are fused in one pass.
 #   5. MVN and MVT have separate hot paths.
 #   6. Independent MVN rectangles are evaluated exactly.
-#   7. MVN uses the folded/tent-transformed Richtmyer rule by default.
+#   7. MVN uses a cached CBC rank-1 lattice with tent transformation by default.
 #   8. MVT uses a batched reduced-dimension Genz transform with folded
 #      conditional Normal coordinates.
 # ─────────────────────────────────────────────────────────────
@@ -440,7 +440,7 @@ end
 @inline _rqmc_coord(r::Int, α::T, shift::T) where {T<:Real} = _open01(_rqmc_raw(r, α, shift))
 
 
-# Folded/tent transformed Richtmyer coordinate used by the Genz MVN rule.
+# Folded/tent-transformed rank-1 lattice coordinate used by the Genz core.
 # This maps frac(rα + shift) to |2u - 1|. It gives the same support (0,1),
 # but usually lowers variation of the transformed integrand for MVN rectangles.
 @inline function _rqmc_folded_coord(r::Int, α::T, shift::T) where {T<:Real}
@@ -932,7 +932,7 @@ end
 
 Rectangular probability for multivariate Gaussian (`ν <= 0`) and
 multivariate Student t (`ν > 0`) distributions using MVSORT plus randomized
-Richtmyer quasi-Monte Carlo.
+randomized rank-1 lattice quasi-Monte Carlo with cached CBC lattice construction.
 
 When `nshifts` is not specified, the core uses 10 randomized shifts for the
 Gaussian case and 8 randomized shifts for the Student t case.

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -46,11 +46,7 @@
 #
 # Near u = 0, evaluate 1 + W₋₁ close to its branch point
 # directly with lambertwbp to avoid catastrophic cancellation.
-@inline function _scale_t_nu4(
-    χ::Distributions.Chisq,
-    invsqrtν::T,
-    u::T,
-) where {T<:AbstractFloat}
+@inline function _scale_t_nu4(χ::Distributions.Chisq, invsqrtν::T, u::T,) where {T<:AbstractFloat}
 
     # Extremely small probabilities are essentially impossible in the
     # randomized QMC loop, but using the generic χ² quantile here preserves
@@ -88,23 +84,13 @@ end
         return sqrt(-log1p(-u))
     elseif ν == 4
         χ = Distributions.Chisq(ν)
-        return _scale_t_nu4(
-            χ,
-            inv(sqrt(T(ν))),
-            u,
-        )
+        return _scale_t_nu4(χ, inv(sqrt(T(ν))), u,)
     end
 
-    return sqrt(
-        T(Distributions.quantile(Distributions.Chisq(ν), u)) / T(ν)
-    )
+    return sqrt(T(Distributions.quantile(Distributions.Chisq(ν), u)) / T(ν))
 end
 
-@inline function _scale_t(
-    χ::Distributions.Chisq,
-    invsqrtν::T,
-    u::T,
-) where {T<:AbstractFloat}
+@inline function _scale_t(χ::Distributions.Chisq, invsqrtν::T, u::T,) where {T<:AbstractFloat}
 
     ν = Distributions.dof(χ)
 
@@ -189,10 +175,8 @@ end
 # ─────────────────────────────────────────────────────────────
 # Swap variables in packed representation
 # ─────────────────────────────────────────────────────────────
-@inline function _mvswap!(p::Int, q::Int,
-                          A::AbstractVector, B::AbstractVector,
-                          DL::AbstractVector, INFI::AbstractVector{Int},
-                          COV::AbstractVector, n::Int)
+@inline function _mvswap!(p::Int, q::Int, A::AbstractVector, B::AbstractVector, DL::AbstractVector,
+                          INFI::AbstractVector{Int}, COV::AbstractVector, n::Int)
     p == q && return
 
     A[p], A[q] = A[q], A[p]
@@ -223,10 +207,8 @@ end
 # This is the Genz variable sorting step. It moves fully infinite variables
 # to the end, then greedily pivots by the smallest conditional probability.
 # ─────────────────────────────────────────────────────────────
-function mvsort!(A::AbstractVector{T}, B::AbstractVector{T},
-                 DL::AbstractVector{T}, INFI::AbstractVector{Int},
-                 COV::AbstractVector{T}, n::Int;
-                 pivot::Bool=true, eps::Real=1e-10) where {T<:Real}
+function mvsort!(A::AbstractVector{T}, B::AbstractVector{T}, DL::AbstractVector{T}, INFI::AbstractVector{Int},
+                 COV::AbstractVector{T}, n::Int; pivot::Bool=true, eps::Real=1e-10) where {T<:Real}
 
     @assert length(A) == n == length(B) == length(DL) == length(INFI)
     @assert length(COV) == n * (n + 1) ÷ 2
@@ -373,12 +355,9 @@ end
 # ─────────────────────────────────────────────────────────────
 # Preparation from covariance/correlation matrix
 # ─────────────────────────────────────────────────────────────
-function mvprep(Σ::AbstractMatrix{T},
-                a::AbstractVector{T}, b::AbstractVector{T};
-                δ::AbstractVector{T}=zeros(T, size(Σ, 1)),
-                assume_correlation::Bool=false,
-                pivot::Bool=true,
-                eps::Real=1e-10) where {T<:Real}
+function mvprep(Σ::AbstractMatrix{T}, a::AbstractVector{T}, b::AbstractVector{T};
+                δ::AbstractVector{T}=zeros(T, size(Σ, 1)), assume_correlation::Bool=false,
+                pivot::Bool=true, eps::Real=1e-10) where {T<:Real}
 
     n = size(Σ, 1)
     @assert size(Σ) == (n, n)
@@ -435,8 +414,7 @@ function mvprep(Σ::AbstractMatrix{T},
     end
 
     nd, y, inform = mvsort!(A, B, DL, INFI, COV, n; pivot=pivot, eps=eps)
-    return (nd=nd, A=A, B=B, DL=DL, INFI=INFI,
-            COV=PackedMatrix{T}(COV, n), Y=y, inform=inform)
+    return (nd=nd, A=A, B=B, DL=DL, INFI=INFI, COV=PackedMatrix{T}(COV, n), Y=y, inform=inform)
 end
 
 # ─────────────────────────────────────────────────────────────
@@ -459,9 +437,8 @@ end
     return u - floor(u)
 end
 
-@inline function _rqmc_coord(r::Int, α::T, shift::T) where {T<:Real}
-    return _open01(_rqmc_raw(r, α, shift))
-end
+@inline _rqmc_coord(r::Int, α::T, shift::T) where {T<:Real} = _open01(_rqmc_raw(r, α, shift))
+
 
 # Folded/tent transformed Richtmyer coordinate used by the Genz MVN rule.
 # This maps frac(rα + shift) to |2u - 1|. It gives the same support (0,1),
@@ -471,9 +448,7 @@ end
     return _open01(abs(T(2) * u - one(T)))
 end
 
-@inline function _rqmc_coord_antithetic(r::Int, α::T, shift::T) where {T<:Real}
-    return _open01(one(T) - _rqmc_raw(r, α, shift))
-end
+@inline _rqmc_coord_antithetic(r::Int, α::T, shift::T) where {T<:Real} = _open01(one(T) - _rqmc_raw(r, α, shift))
 
 @inline function _qmc_error(vals::AbstractVector{T}) where {T<:Real}
     n = length(vals)
@@ -498,10 +473,8 @@ function _is_diagonal(Σ::AbstractMatrix{T}, n::Int) where {T<:Real}
     return true
 end
 
-function _mvn_independent_cdf(Σ::AbstractMatrix{T},
-                              a::AbstractVector{T}, b::AbstractVector{T},
-                              δ::AbstractVector{T};
-                              assume_correlation::Bool=false) where {T<:Real}
+function _mvn_independent_cdf(Σ::AbstractMatrix{T}, a::AbstractVector{T}, b::AbstractVector{T},
+                              δ::AbstractVector{T}; assume_correlation::Bool=false) where {T<:Real}
     n = length(a)
     value = one(T)
 
@@ -524,12 +497,9 @@ end
 # MVT uses q = nd coordinates: 1 for the radial χ² scale and nd - 1 for
 # the conditional normal transform.
 # ─────────────────────────────────────────────────────────────
-function _mvn_integrand_rqmc!(y::AbstractVector{T}, r::Int,
-                              α::AbstractVector{T}, shift::AbstractVector{T},
-                              nd::Int,
-                              A::AbstractVector{T}, B::AbstractVector{T}, DL::AbstractVector{T},
-                              INFI::AbstractVector{Int}, COV::PackedMatrix{T},
-                              antithetic::Bool) where {T<:Real}
+function _mvn_integrand_rqmc!(y::AbstractVector{T}, r::Int, α::AbstractVector{T}, shift::AbstractVector{T},
+                              nd::Int, A::AbstractVector{T}, B::AbstractVector{T}, DL::AbstractVector{T},
+                              INFI::AbstractVector{Int}, COV::PackedMatrix{T}, antithetic::Bool) where {T<:Real}
     value = one(T)
 
     @inbounds begin
@@ -569,21 +539,17 @@ function _mvn_integrand_rqmc!(y::AbstractVector{T}, r::Int,
     return value
 end
 
-function _mvt_integrand_rqmc!(y::AbstractVector{T}, r::Int,
-                              α::AbstractVector{T}, shift::AbstractVector{T},
-                              nd::Int,
-                              A::AbstractVector{T}, B::AbstractVector{T}, DL::AbstractVector{T},
-                              INFI::AbstractVector{Int}, COV::PackedMatrix{T},
-                              χ::Distributions.Chisq,
-                              invsqrtν::T,
-                              antithetic::Bool) where {T<:Real}
+function _mvt_integrand_rqmc!(y::AbstractVector{T}, r::Int, α::AbstractVector{T}, shift::AbstractVector{T},
+                              nd::Int, A::AbstractVector{T}, B::AbstractVector{T}, DL::AbstractVector{T},
+                              INFI::AbstractVector{Int}, COV::PackedMatrix{T}, χ::Distributions.Chisq,
+                              invsqrtν::T, antithetic::Bool) where {T<:Real}
     value = one(T)
 
     @inbounds begin
-        # First QMC coordinate is the common t scale. We keep it non-folded:
-        # the χ² quantile has difficult endpoints, and folding it tends to
-        # oversample both tails in a way that is not consistently beneficial.
-        uχ = _rqmc_coord(r, α[1], shift[1])
+        # First QMC coordinate is the common t scale. The same tent
+        # periodization used by the conditional Normal coordinates is applied
+        # to the radial coordinate for the CBC lattice.
+        uχ = _rqmc_folded_coord(r, α[1], shift[1])
         R = _scale_t(χ, invsqrtν, uχ)
 
         s = DL[1]
@@ -623,10 +589,10 @@ function _mvt_integrand_rqmc!(y::AbstractVector{T}, r::Int,
 end
 
 # ─────────────────────────────────────────────────────────────
-# Randomized Richtmyer QMC drivers
+# Randomized rank-1 lattice QMC drivers
 # ─────────────────────────────────────────────────────────────
 # ─────────────────────────────────────────────────────────────
-# Batched MVN Richtmyer QMC driver
+# Batched MVN randomized-lattice QMC driver
 #
 # The scalar Genz transform is memory-light but pays substantial overhead per
 # point. This batch version evaluates many QMC points for one random shift in a
@@ -734,25 +700,21 @@ function _mvn_integrand_rqmc_batch!(pv::AbstractVector{T},
     end
 end
 
-function _rqmc_integrate_mvn(nd::Int,
-                             A::AbstractVector{T}, B::AbstractVector{T}, DL::AbstractVector{T},
-                             INFI::AbstractVector{Int}, COV::PackedMatrix{T};
-                             maxpts::Int,
-                             abseps::Real,
-                             releps::Real,
-                             rng=Random.default_rng(),
-                             antithetic::Bool=false,
-                             nshifts::Int=12,
+function _rqmc_integrate_mvn(nd::Int, A::AbstractVector{T}, B::AbstractVector{T}, DL::AbstractVector{T},
+                             INFI::AbstractVector{Int}, COV::PackedMatrix{T}; maxpts::Int, abseps::Real,
+                             releps::Real, rng=Random.default_rng(), antithetic::Bool=false, nshifts::Int=12,
                              batchsize::Int=0) where {T<:Real}
     qdim = nd - 1
     qdim <= 0 && return (value=one(T), error=zero(T), inform=0)
 
-    α = richtmyer_roots(T, qdim + 1)
+    per_point = antithetic ? 2 : 1
+    requested_nper = max(1, maxpts ÷ (nshifts * per_point),)
+
+    α, nper = _qmc_lattice(T, qdim, requested_nper,)
+
     shift = Vector{T}(undef, qdim)
     vals = Vector{T}(undef, nshifts)
 
-    per_point = antithetic ? 2 : 1
-    nper = max(1, maxpts ÷ (nshifts * per_point))
     bsz = batchsize > 0 ? min(batchsize, nper) : _default_mvn_batchsize(nper, nd)
 
     # y stores only the generated conditional Normal quantiles y₁,…,y_{nd-1}.
@@ -770,13 +732,11 @@ function _rqmc_integrate_mvn(nd::Int,
         r0 = 1
         while r0 <= nper
             nb = min(bsz, nper - r0 + 1)
-            acc += _mvn_integrand_rqmc_batch!(pv, y, work, r0, nb,
-                                              α, shift, nd, A, B, DL,
-                                              INFI, COV, false)
+            acc += _mvn_integrand_rqmc_batch!(pv, y, work, r0, nb, α, shift,
+                                              nd, A, B, DL, INFI, COV, false)
             if antithetic
-                acc += _mvn_integrand_rqmc_batch!(pv, y, work, r0, nb,
-                                                  α, shift, nd, A, B, DL,
-                                                  INFI, COV, true)
+                acc += _mvn_integrand_rqmc_batch!(pv, y, work, r0, nb, α, shift,
+                                                  nd, A, B, DL, INFI, COV, true)
             end
             r0 += nb
         end
@@ -820,7 +780,7 @@ function _mvt_integrand_rqmc_batch!(pv::AbstractVector{T},
         shχ = shift[1]
         for i in 1:nb
             r = r0 + i - 1
-            uχ = _rqmc_coord(r, aχ, shχ)
+            uχ = _rqmc_folded_coord(r, aχ, shχ)
             scale[i] = _scale_t(χ, invsqrtν, uχ)
         end
 
@@ -914,12 +874,14 @@ function _rqmc_integrate_mvt(nd::Int,
     qdim = nd
     qdim <= 0 && return (value=one(T), error=zero(T), inform=0)
 
-    α = richtmyer_roots(T, qdim + 1)
+    per_point = antithetic ? 2 : 1
+    requested_nper = max(1, maxpts ÷ (nshifts * per_point),)
+
+    α, nper = _qmc_lattice(T, qdim, requested_nper,)
+
     shift = Vector{T}(undef, qdim)
     vals = Vector{T}(undef, nshifts)
 
-    per_point = antithetic ? 2 : 1
-    nper = max(1, maxpts ÷ (nshifts * per_point))
     bsz = batchsize > 0 ? min(batchsize, nper) : _default_mvt_batchsize(nper, nd)
 
     # Only y₁,…,y_{nd-1} are needed. The last level contributes only a mass.
@@ -941,15 +903,11 @@ function _rqmc_integrate_mvt(nd::Int,
         r0 = 1
         while r0 <= nper
             nb = min(bsz, nper - r0 + 1)
-            acc += _mvt_integrand_rqmc_batch!(pv, y, work, scale,
-                                              r0, nb, α, shift, nd,
-                                              A, B, DL, INFI, COV,
-                                              χ, invsqrtν, false)
+            acc += _mvt_integrand_rqmc_batch!(pv, y, work, scale, r0, nb, α, shift, nd,
+                                              A, B, DL, INFI, COV, χ, invsqrtν, false)
             if antithetic
-                acc += _mvt_integrand_rqmc_batch!(pv, y, work, scale,
-                                                  r0, nb, α, shift, nd,
-                                                  A, B, DL, INFI, COV,
-                                                  χ, invsqrtν, true)
+                acc += _mvt_integrand_rqmc_batch!(pv, y, work, scale, r0, nb, α, shift, nd,
+                                                  A, B, DL, INFI, COV, χ, invsqrtν, true)
             end
             r0 += nb
         end
@@ -1029,11 +987,7 @@ function mvtcdf(Σ::AbstractMatrix{T},
         return (value=value, error=zero(T), inform=0)
     end
 
-    res = mvprep(Σ, a, b;
-                 δ=δ,
-                 assume_correlation=assume_correlation,
-                 pivot=pivot,
-                 eps=1e-10)
+    res = mvprep(Σ, a, b; δ=δ, assume_correlation=assume_correlation, pivot=pivot, eps=1e-10)
 
     if res.inform == 3
         return (value=zero(T), error=one(T), inform=3)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -32,10 +32,35 @@
 # avoid constructing Chisq(ν) at every QMC point.
 @inline function _scale_t(ν::Real, u::T) where {T<:Real}
     @assert ν > 0
+
+    if ν == 1
+        # χ²₁ quantile:
+        # Q(u) = 2 * erfinv(u)^2.
+        # Since u ∈ (0, 1), erfinv(u) ≥ 0, hence
+        # sqrt(Q(u)) = sqrt(2) * erfinv(u).
+        return sqrt(T(2)) * T(SpecialFunctions.erfinv(u))
+    elseif ν == 2
+        # χ²₂ ~ Exponential(scale=2), so
+        # sqrt(Q(u) / 2) = sqrt(-log(1-u)).
+        return sqrt(-log1p(-u))
+    end
+
     return sqrt(T(Distributions.quantile(Distributions.Chisq(ν), u)) / T(ν))
 end
 
-@inline function _scale_t(χ::Distributions.Chisq, invsqrtν::T, u::T) where {T<:Real}
+@inline function _scale_t(
+    χ::Distributions.Chisq,
+    invsqrtν::T,
+    u::T,
+) where {T<:Real}
+    ν = Distributions.dof(χ)
+
+    if ν == 1
+        return sqrt(T(2)) * T(SpecialFunctions.erfinv(u))
+    elseif ν == 2
+        return sqrt(-log1p(-u))
+    end
+
     return sqrt(T(Distributions.quantile(χ, u))) * invsqrtν
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -71,34 +71,33 @@
     end
 end
 
-@inline function _scale_t(ν::Real, u::T) where {T<:AbstractFloat}
+@inline function _scale_t(ν::Real, u::T) where {T<:Real}
     @assert ν > 0
 
-    if ν == 1
-        # χ²₁ quantile:
-        # sqrt(Q(u)) = sqrt(2) * erfinv(u).
+    if T <: AbstractFloat && ν == 1
         return sqrt(T(2)) * T(SpecialFunctions.erfinv(u))
-    elseif ν == 2
-        # χ²₂ ~ Exponential(scale=2):
-        # sqrt(Q(u)/2) = sqrt(-log(1-u)).
+    elseif T <: AbstractFloat && ν == 2
         return sqrt(-log1p(-u))
-    elseif ν == 4
+    elseif T <: AbstractFloat && ν == 4
         χ = Distributions.Chisq(ν)
-        return _scale_t_nu4(χ, inv(sqrt(T(ν))), u,)
+        return _scale_t_nu4(χ, inv(sqrt(T(ν))), u)
     end
 
     return sqrt(T(Distributions.quantile(Distributions.Chisq(ν), u)) / T(ν))
 end
 
-@inline function _scale_t(χ::Distributions.Chisq, invsqrtν::T, u::T,) where {T<:AbstractFloat}
-
+@inline function _scale_t(
+    χ::Distributions.Chisq,
+    invsqrtν::T,
+    u::T,
+) where {T<:Real}
     ν = Distributions.dof(χ)
 
-    if ν == 1
+    if T <: AbstractFloat && ν == 1
         return sqrt(T(2)) * T(SpecialFunctions.erfinv(u))
-    elseif ν == 2
+    elseif T <: AbstractFloat && ν == 2
         return sqrt(-log1p(-u))
-    elseif ν == 4
+    elseif T <: AbstractFloat && ν == 4
         return _scale_t_nu4(χ, invsqrtν, u)
     end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -702,7 +702,7 @@ end
 
 function _rqmc_integrate_mvn(nd::Int, A::AbstractVector{T}, B::AbstractVector{T}, DL::AbstractVector{T},
                              INFI::AbstractVector{Int}, COV::PackedMatrix{T}; maxpts::Int, abseps::Real,
-                             releps::Real, rng=Random.default_rng(), antithetic::Bool=false, nshifts::Int=12,
+                             releps::Real, rng=Random.default_rng(), antithetic::Bool=false, nshifts::Int=10,
                              batchsize::Int=0) where {T<:Real}
     qdim = nd - 1
     qdim <= 0 && return (value=one(T), error=zero(T), inform=0)
@@ -934,7 +934,7 @@ Rectangular probability for multivariate Gaussian (`ν <= 0`) and
 multivariate Student t (`ν > 0`) distributions using MVSORT plus randomized
 Richtmyer quasi-Monte Carlo.
 
-When `nshifts` is not specified, the core uses 12 randomized shifts for the
+When `nshifts` is not specified, the core uses 10 randomized shifts for the
 Gaussian case and 16 randomized shifts for the Student t case.
 
 Returns a named tuple `(value, error, inform)`.
@@ -968,7 +968,7 @@ function mvtcdf(Σ::AbstractMatrix{T},
     @assert size(Σ) == (n, n)
     @assert length(a) == n == length(b) == length(δ)
 
-    nshifts_eff = isnothing(nshifts) ? (ν > 0 ? 16 : 12) : nshifts
+    nshifts_eff = isnothing(nshifts) ? (ν > 0 ? 16 : 10) : nshifts
     if nshifts_eff < 2
         throw(ArgumentError("nshifts must be at least 2"))
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -869,7 +869,7 @@ function _rqmc_integrate_mvt(nd::Int,
                              releps::Real,
                              rng=Random.default_rng(),
                              antithetic::Bool=false,
-                             nshifts::Int=12,
+                             nshifts::Int=8,
                              batchsize::Int=0) where {T<:Real}
     qdim = nd
     qdim <= 0 && return (value=one(T), error=zero(T), inform=0)
@@ -935,7 +935,7 @@ multivariate Student t (`ν > 0`) distributions using MVSORT plus randomized
 Richtmyer quasi-Monte Carlo.
 
 When `nshifts` is not specified, the core uses 10 randomized shifts for the
-Gaussian case and 16 randomized shifts for the Student t case.
+Gaussian case and 8 randomized shifts for the Student t case.
 
 Returns a named tuple `(value, error, inform)`.
 
@@ -968,7 +968,7 @@ function mvtcdf(Σ::AbstractMatrix{T},
     @assert size(Σ) == (n, n)
     @assert length(a) == n == length(b) == length(δ)
 
-    nshifts_eff = isnothing(nshifts) ? (ν > 0 ? 16 : 10) : nshifts
+    nshifts_eff = isnothing(nshifts) ? (ν > 0 ? 8 : 10) : nshifts
     if nshifts_eff < 2
         throw(ArgumentError("nshifts must be at least 2"))
     end

--- a/test/multivariate_qmc_cbc_test.jl
+++ b/test/multivariate_qmc_cbc_test.jl
@@ -1,0 +1,96 @@
+@testitem "Fast CBC lattice construction and cache" begin
+    using AdditionalDistributions
+
+    const AD = AdditionalDistributions
+
+    α, p = AD._qmc_lattice(Float64, 3, 625)
+
+    @test p == 619
+    @test length(α) == 3
+    @test round.(Int, α .* p) == [1, 259, 117]
+    @test all(x -> 0.0 < x < 1.0, α)
+
+    α2, p2 = AD._qmc_lattice(Float64, 3, 625)
+
+    @test p2 == p
+    @test α2 === α
+
+    αsmall, nsmall =
+        AD._qmc_lattice(Float64, 3, 2)
+
+    @test nsmall == 2
+    @test αsmall ==
+        AD.richtmyer_roots(Float64, 4)
+end
+
+@testitem "CBC-backed MVN preserves public CDF contract" begin
+    using AdditionalDistributions
+    using Distributions
+    using StableRNGs
+
+    Σ = [
+        1.0 0.3 0.3
+        0.3 1.0 0.3
+        0.3 0.3 1.0
+    ]
+
+    d = MvNormal(zeros(3), Σ)
+    a = fill(-1.0, 3)
+    b = fill(1.0, 3)
+
+    result = AdditionalDistributions.cdf_result(
+        d,
+        a,
+        b;
+        m=10_000,
+        abseps=0.0,
+        releps=0.0,
+        nshifts=12,
+        rng=StableRNG(20260824),
+    )
+
+    @test 0.0 <= result.value <= 1.0
+    @test isapprox(
+        result.value,
+        0.3383461438763211;
+        atol=2e-5,
+        rtol=0,
+    )
+
+    @test result.neval == 10_000
+end
+
+@testitem "CBC plus radial tent MVT smoke test" begin
+    using AdditionalDistributions
+    using StableRNGs
+
+    Σ = [
+        1.0 0.3 0.3
+        0.3 1.0 0.3
+        0.3 0.3 1.0
+    ]
+
+    d = MvTStudent(4.0, Σ)
+    a = fill(-1.0, 3)
+    b = fill(1.0, 3)
+
+    result = cdf_result(
+        d,
+        a,
+        b;
+        m=10_000,
+        abseps=0.0,
+        releps=0.0,
+        nshifts=12,
+        rng=StableRNG(20260824),
+    )
+
+    @test 0.0 <= result.value <= 1.0
+    @test isapprox(
+        result.value,
+        0.31181962814543895;
+        atol=5e-4,
+        rtol=0,
+    )
+    @test result.neval == 10_000
+end

--- a/test/multivariate_qmc_cbc_test.jl
+++ b/test/multivariate_qmc_cbc_test.jl
@@ -94,3 +94,44 @@ end
     )
     @test result.neval == 10_000
 end
+
+@testitem "Gaussian default QMC shift count" begin
+    using AdditionalDistributions
+    using Distributions
+    using LinearAlgebra
+    using Random
+
+    d = 3
+    ρ = 0.3
+
+    Σ = fill(ρ, d, d)
+    Σ[diagind(Σ)] .= 1.0
+
+    dist = MvNormal(zeros(d), Σ)
+    lower = fill(-1.0, d)
+    upper = fill(1.0, d)
+
+    seed = 20260824
+
+    default_result = cdf_result(
+        dist,
+        lower,
+        upper;
+        m=10_000,
+        rng=MersenneTwister(seed),
+    )
+
+    explicit_result = cdf_result(
+        dist,
+        lower,
+        upper;
+        m=10_000,
+        nshifts=10,
+        rng=MersenneTwister(seed),
+    )
+
+    @test default_result.value == explicit_result.value
+    @test default_result.error == explicit_result.error
+    @test default_result.inform == explicit_result.inform
+    @test default_result.neval == explicit_result.neval
+end

--- a/test/multivariate_qmc_cbc_test.jl
+++ b/test/multivariate_qmc_cbc_test.jl
@@ -135,3 +135,45 @@ end
     @test default_result.inform == explicit_result.inform
     @test default_result.neval == explicit_result.neval
 end
+
+@testitem "Student-t default QMC shift count" begin
+    using AdditionalDistributions
+    using Distributions
+    using LinearAlgebra
+    using Random
+
+    d = 3
+    ρ = 0.3
+    ν = 4.0
+
+    Σ = fill(ρ, d, d)
+    Σ[diagind(Σ)] .= 1.0
+
+    dist = MvTDist(ν, zeros(d), Σ)
+    lower = fill(-1.0, d)
+    upper = fill(1.0, d)
+
+    seed = 20260824
+
+    default_result = cdf_result(
+        dist,
+        lower,
+        upper;
+        m=10_000,
+        rng=MersenneTwister(seed),
+    )
+
+    explicit_result = cdf_result(
+        dist,
+        lower,
+        upper;
+        m=10_000,
+        nshifts=8,
+        rng=MersenneTwister(seed),
+    )
+
+    @test default_result.value == explicit_result.value
+    @test default_result.error == explicit_result.error
+    @test default_result.inform == explicit_result.inform
+    @test default_result.neval == explicit_result.neval
+end

--- a/test/multivariate_student_radial_fastpath_test.jl
+++ b/test/multivariate_student_radial_fastpath_test.jl
@@ -162,3 +162,17 @@
         )
     end
 end
+
+@testitem "Student-t radial scaling keeps generic Real dispatch" begin
+    using AdditionalDistributions
+    using Distributions
+    using ForwardDiff
+
+    const AD = AdditionalDistributions
+
+    u = ForwardDiff.Dual{Nothing}(0.37, 1.0)
+    invsqrtν = one(u) / sqrt(5.0)
+
+    @test applicable(AD._scale_t, 5.0, u)
+    @test applicable(AD._scale_t, Chisq(5.0), invsqrtν, u)
+end

--- a/test/multivariate_student_radial_fastpath_test.jl
+++ b/test/multivariate_student_radial_fastpath_test.jl
@@ -5,8 +5,135 @@
 
     const AD = AdditionalDistributions
 
-    ps = [
-        eps(Float64),
+    # ---------------------------------------------------------
+    # Ordinary range:
+    # compare against the generic Distributions quantile.
+    # ---------------------------------------------------------
+    ps_regular = Float64[
+        1e-12,
+        1e-10,
+        1e-8,
+        1e-6,
+        1e-4,
+        0.01,
+        0.1,
+        0.5,
+        0.9,
+        0.99,
+        1 - 1e-8,
+        1 - 1e-12,
+    ]
+
+    for ν in (1.0, 2.0, 4.0)
+        χ = Chisq(ν)
+        invsqrtν = inv(sqrt(ν))
+
+        for p in ps_regular
+            fast = AD._scale_t(χ, invsqrtν, p)
+            ref = sqrt(quantile(χ, p) / ν)
+
+            @test isfinite(fast)
+            @test fast >= 0
+            @test isapprox(
+                fast,
+                ref;
+                rtol=1e-11,
+                atol=1e-14,
+            )
+        end
+    end
+
+    # ---------------------------------------------------------
+    # ν = 1:
+    #
+    # χ²₁ = Z², hence for the radial scale
+    #
+    #   R = sqrt(Qχ²₁(p))
+    #     = sqrt(2) * erfinv(p).
+    #
+    # Do NOT use Chisq.quantile as the reference in the
+    # extreme lower tail: its relative accuracy there is not
+    # suitable for validating this analytical fast path.
+    #
+    # Instead verify the inverse identity
+    #
+    #   p = erf(R / sqrt(2)).
+    # ---------------------------------------------------------
+    χ1 = Chisq(1.0)
+
+    ps_nu1_tail = Float64[
+        1e-300,
+        1e-200,
+        1e-100,
+        1e-50,
+        1e-30,
+        1e-20,
+        1e-16,
+        1e-14,
+    ]
+
+    let previous = 0.0
+        for p in ps_nu1_tail
+            r = AD._scale_t(χ1, 1.0, p)
+
+            @test isfinite(r)
+            @test r >= 0
+            @test r >= previous
+
+            p_back = AD.SpecialFunctions.erf(r / sqrt(2.0))
+
+            @test isapprox(
+                p_back,
+                p;
+                rtol=5e-13,
+                atol=0.0,
+            )
+
+            previous = r
+        end
+    end
+
+    # ---------------------------------------------------------
+    # ν = 2:
+    #
+    # χ²₂ ~ Exponential(scale=2), therefore
+    #
+    #   sqrt(Qχ²₂(p) / 2) = sqrt(-log(1-p)).
+    # ---------------------------------------------------------
+    χ2 = Chisq(2.0)
+
+    for p in ps_regular
+        fast = AD._scale_t(
+            χ2,
+            inv(sqrt(2.0)),
+            p,
+        )
+
+        exact = sqrt(-log1p(-p))
+
+        @test fast == exact
+    end
+
+    # ---------------------------------------------------------
+    # ν = 4:
+    #
+    # Verify the Lambert-W implementation throughout the
+    # ordinary range and deep lower/upper tails.
+    #
+    # The smallest Float64 value deliberately exercises the
+    # generic χ² fallback.
+    # ---------------------------------------------------------
+    χ4 = Chisq(4.0)
+
+    ps_nu4 = Float64[
+        nextfloat(0.0),
+        1e-300,
+        1e-200,
+        1e-100,
+        1e-50,
+        1e-30,
+        1e-20,
+        1e-16,
         1e-12,
         1e-8,
         1e-4,
@@ -20,22 +147,18 @@
         prevfloat(1.0),
     ]
 
-    for ν in (1.0, 2.0)
-        χ = Chisq(ν)
-        invsqrtν = inv(sqrt(ν))
+    for p in ps_nu4
+        fast = AD._scale_t(χ4, 0.5, p)
+        ref = sqrt(quantile(χ4, p) / 4.0)
 
-        for p in ps
-            fast = AD._scale_t(χ, invsqrtν, p)
-            ref = sqrt(quantile(χ, p) / ν)
+        @test isfinite(fast)
+        @test fast >= 0
 
-            @test isfinite(fast)
-            @test fast >= 0
-            @test isapprox(
-                fast,
-                ref;
-                rtol=1e-11,
-                atol=1e-14,
-            )
-        end
+        @test isapprox(
+            fast,
+            ref;
+            rtol=5e-13,
+            atol=1e-14,
+        )
     end
 end

--- a/test/multivariate_student_radial_fastpath_test.jl
+++ b/test/multivariate_student_radial_fastpath_test.jl
@@ -1,0 +1,41 @@
+@testitem "Student radial exact fast paths" begin
+    using Test
+    using Distributions
+    using AdditionalDistributions
+
+    const AD = AdditionalDistributions
+
+    ps = [
+        eps(Float64),
+        1e-12,
+        1e-8,
+        1e-4,
+        0.01,
+        0.1,
+        0.5,
+        0.9,
+        0.99,
+        1 - 1e-8,
+        1 - 1e-12,
+        prevfloat(1.0),
+    ]
+
+    for ν in (1.0, 2.0)
+        χ = Chisq(ν)
+        invsqrtν = inv(sqrt(ν))
+
+        for p in ps
+            fast = AD._scale_t(χ, invsqrtν, p)
+            ref = sqrt(quantile(χ, p) / ν)
+
+            @test isfinite(fast)
+            @test fast >= 0
+            @test isapprox(
+                fast,
+                ref;
+                rtol=1e-11,
+                atol=1e-14,
+            )
+        end
+    end
+end


### PR DESCRIPTION
## Summary

This PR improves the numerical core used for multivariate Gaussian and Student-t rectangular probabilities, focusing on accuracy per evaluation, runtime, and memory while preserving the public API and `CDFResult.neval` semantics introduced previously.

### Main changes

- Replace the default floating-point Richtmyer rule with a cached component-by-component (CBC) rank-1 lattice.
- Use randomized shifts with tent-transformed coordinates.
- Apply the tent transformation to the Student-t radial chi-square coordinate.
- Add specialized Student-t radial scaling paths for:
  - `ν = 1`
  - `ν = 2`
  - `ν = 4`
- Tune the default randomized-shift counts:
  - Gaussian: `nshifts = 10`
  - Student-t: `nshifts = 8`
- Retain the previous Richtmyer construction as a fallback for very small budgets and non-floating scalar types.
- Add deterministic tests for the CBC construction/cache and Student-t radial fast paths.
- Update the numerical documentation and benchmark methodology.

## CBC lattice construction

The new floating-point QMC path constructs a rank-1 lattice using a fast component-by-component procedure and caches the generating vector by scalar type, QMC dimension, and prime lattice size.

The Gaussian integration dimension is `d - 1`.

The Student-t integration dimension is `d`, including the radial chi-square coordinate.

The lattice size is prime-rounded from the available per-shift budget, so the actual number of lattice evaluations may be slightly smaller than the nominal budget. `CDFResult.neval` intentionally retains the requested-budget convention for API compatibility.

## Validation

The implementation was validated against independent deterministic reference probabilities rather than treating another randomized QMC implementation as ground truth.

### Gaussian

48 structured cases covering:

- `d ∈ {3, 10, 20, 50}`
- equicorrelation and AR(1)
- `ρ ∈ {0.3, 0.95}`
- central, lower-tail, and mixed rectangles
- nominal budgets `10_000` and `100_000`
- five randomized seeds

At nominal budget `100_000`, AdditionalDistributions.jl had lower case-wise median absolute error than SciPy in 30 cases versus 15 for SciPy, with 3 unresolved cases, while also having lower median runtime in the benchmark environment.

### Student-t

72 structured cases covering:

- `d ∈ {3, 10}`
- equicorrelation and AR(1)
- `ρ ∈ {0.3, 0.95}`
- `ν ∈ {1, 4, 10}`
- central, lower-tail, and mixed rectangles
- nominal budgets `10_000` and `100_000`
- five randomized seeds

At nominal budget `100_000`:

- AdditionalDistributions.jl vs SciPy: 42 vs 30 case-wise wins
- AdditionalDistributions.jl vs R `mvtnorm`: 69 vs 3 case-wise wins

Median runtime was approximately:

- AdditionalDistributions.jl: 44.5 ms
- SciPy: 65.3 ms
- R `mvtnorm`: 94.0 ms

These results are benchmark-specific and are documented as an accuracy/runtime comparison, not as a universal performance claim.

## Tests

```text
AdditionalDistributions | 3725 / 3725 passed
```

The documentation also builds successfully with Documenter/DocumenterVitepress.

### Notes

Large experimental benchmark scripts and generated CSV files used during algorithm selection are intentionally not included in this PR.